### PR TITLE
feat: 銀行取引CSVインポート機能の追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ GEMINI_API_KEY=your_gemini_api_key
 # Google Sheets
 SPREADSHEET_ID=your_spreadsheet_id
 SHEET_NAME=receipts
+LOGS_SHEET_NAME=logs
 
 # GCP サービスアカウントの JSON キー（1行に圧縮したもの）
 GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"..."}
@@ -15,4 +16,3 @@ GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"..."}
 # 銀行取引インポート
 BANK_FOLDER_ID=your_bank_folder_id
 BANK_TRANS_SHEET_NAME=bank trans
-LOGS_SHEET_NAME=logs

--- a/.env.example
+++ b/.env.example
@@ -15,4 +15,4 @@ GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"..."}
 # 銀行取引インポート
 BANK_FOLDER_ID=your_bank_folder_id
 BANK_TRANS_SHEET_NAME=bank trans
-BANK_LOGS_SHEET_NAME=logs
+LOGS_SHEET_NAME=logs

--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ SHEET_NAME=receipts
 
 # GCP サービスアカウントの JSON キー（1行に圧縮したもの）
 GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"..."}
+
+# 銀行取引インポート
+BANK_FOLDER_ID=your_bank_folder_id
+BANK_TRANS_SHEET_NAME=bank trans
+BANK_LOGS_SHEET_NAME=logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Claude Code 指示
+
+## ブランチ運用
+
+- 新しいブランチは必ず **main から** 切ること
+- `git checkout main && git pull && git checkout -b feature/xxx` の順で作成する
+- 前のフィーチャーブランチから切らない

--- a/README.md
+++ b/README.md
@@ -1,37 +1,46 @@
 # Receipt Log Bot
 
 LINE グループ内で共有されたレシート画像を自動で解析し、Google Sheets に記録する Bot です。
+また、銀行の取引明細 CSV を Google Drive 経由でスプレッドシートにインポートする機能も備えています。
 
 ## 特徴
 
 - **無料で運用可能** — Cloud Run の無料枠内で動作
-- **グループ対応** — 誰がレシートを申告したかを自動記録
-- **自動解析** — Gemini API でレシート情報を構造化データに変換
+- **グループ対応** — 誰がレシートを申告したか・どのグループからかを自動記録
+- **自動解析** — Gemini API でレシート情報（店名・金額・支払い日時・支払い方法・品目）を構造化データに変換
 - **スプレッドシート統合** — リアルタイムでレシート情報を集計できる
+- **銀行取引インポート** — Shift-JIS の CSV に対応、銀行ごとのマッピング設定で複数口座を管理
 
 ## 使い方
 
-### ボットをグループに追加
+### ① レシートをグループで送信
 
-LINE アプリでボットを招待するだけで OK。
-
-### レシートを送信
-
-グループ内でレシート画像を送ると、ボットが自動で：
-
-1. 画像内の店名・金額・品目を認識
-2. 送信者の名前と USER ID を記録
-3. Google Sheets に追記
-4. スプレッドシート記録完了を返信
+LINE アプリでボットをグループに招待し、レシート画像を送るだけ。
 
 ```
 ✅ 記録しました！
 
 👤 田中太郎
 🏪 セブン-イレブン
-💴 1,280 円
+🗓 2026/04/10 15:32
+💴 1,280 円（現金）
 🛒 おにぎり、コーヒー、弁当
 ```
+
+ボットが自動で店名・金額・支払い日時・支払い方法・品目を認識し、送信者名・グループ ID とともに Google Sheets に追記します。
+
+### ② 銀行取引明細のインポート
+
+Google Drive の指定フォルダに CSV を置いて POST リクエストを送ると、スプレッドシートにインポートされます。
+
+```bash
+curl -X POST https://{cloud-run-url}/bank/import
+```
+
+- 重複チェックあり（同一取引の二重登録を防止）
+- 処理済みファイルは自動で「処理済み」フォルダへ移動
+- 失敗ファイルは「要確認」フォルダへ移動
+- 処理結果は logs シートに記録
 
 ## システム構成
 
@@ -40,12 +49,13 @@ LINE Bot
   ↓ (webhook)
 ├─ Cloud Run (Express)
    ├─ Gemini 2.5 Flash (レシート解析)
-   └─ Google Sheets API (記録)
+   ├─ Google Sheets API (記録)
+   └─ Google Drive API (CSV 取得)
 ```
 
 **無料枠:**
 - Cloud Run: 200万リクエスト/月
-- Gemini API: 1,500リクエスト/日
+- Gemini API: 20リクエスト/日（Free tier）
 - Google Sheets API: 制限なし
 - LINE Messaging API: 返信メッセージは無料
 
@@ -53,21 +63,30 @@ LINE Bot
 
 ```
 src/
-├── index.js         # Express サーバー + Webhook エンドポイント
-├── lineHandler.js   # LINE イベント処理（画像受信・ユーザー取得）
-├── geminiParser.js  # Gemini で画像をレシートデータに変換
-└── sheetsLogger.js  # Google Sheets に記録
+├── index.js                 # Express サーバー + Webhook / bank/import エンドポイント
+├── lineHandler.js           # LINE イベント処理（画像受信・ユーザー取得）
+├── geminiParser.js          # Gemini でレシート画像を構造化データに変換
+├── sheetsLogger.js          # receipts シートに記録
+├── bankTransactionImporter.js  # 銀行取引インポート処理のオーケストレーション
+├── bankCsvParser.js         # CSV パース（Shift-JIS 対応・半角カナ全角変換）
+├── bankTransactionDedup.js  # 重複チェック
+├── bankDriveHelper.js       # Google Drive からの CSV 取得・移動
+└── logger.js                # logs シートへの処理結果記録
+
+conf/
+└── bank_mapping/            # 銀行ごとのマッピング設定
+    └── saitamaresona.json   # 埼玉りそな銀行用サンプル
 
 docs/
 ├── SETUP.md         # セットアップ手順
 ├── ARCHITECTURE.md  # システム設計書
 ├── API.md           # API 仕様書
-└── QUICKREF.md      # 開発用チートシート
+├── QUICKREF.md      # 開発用チートシート
+└── MONITORING.md    # 監視・運用手順
 
 package.json         # 依存パッケージ
-Dockerfile          # Cloud Run デプロイ用
-.env.example        # 環境変数テンプレート
-README.md           # このファイル
+Dockerfile           # Cloud Run デプロイ用
+.env.example         # 環境変数テンプレート
 ```
 
 ## クイックスタート
@@ -81,38 +100,66 @@ README.md           # このファイル
 ## 技術スタック
 
 - **Node.js 20** — バックエンド
-- **Express** — Web 框架
+- **Express** — Web フレームワーク
 - **@line/bot-sdk** — LINE Messaging API クライアント
 - **@google/generative-ai** — Gemini API クライアント
-- **googleapis** — Google Sheets API クライアント
+- **googleapis** — Google Sheets / Drive API クライアント
+- **iconv-lite** — Shift-JIS CSV デコード
 - **Cloud Run** — ホスティング
 
-## 費用
+## スプレッドシートの構成
 
-月間 100 件のレシート申告の場合：
+### receipts シート（レシート記録）
 
-| 項目 | 費用 |
-|------|------|
-| Cloud Run | 0円（無料枠内） |
-| Gemini API | 100 × ¥0.075 = ¥7.5 |
-| Google Sheets API | 0円 |
-| **合計** | **¥7.5/月程度** |
+| 列 | 項目 |
+|----|------|
+| A | 受信日時 |
+| B | 支払い日時 |
+| C | LINE UserID |
+| D | 表示名 |
+| E | グループID |
+| F | 店名 |
+| G | 合計金額（円）|
+| H | 支払い方法 |
+| I | 品目 |
+| J | 備考 |
+
+### bank trans シート（銀行取引）
+
+| 列 | 項目 |
+|----|------|
+| A | 取引日 |
+| B | 金額 |
+| C | 区分 |
+| D | 残高 |
+| E | 摘要 |
+| F | コメント |
+| G | カテゴリ（自動）|
+| H | 銀行名 |
+
+### logs シート（インポート処理ログ）
+
+| 列 | 項目 |
+|----|------|
+| A | タイムスタンプ |
+| B | 処理名 |
+| C | 銀行名 |
+| D | ファイル名 |
+| E | ステータス |
+| F | 総行数 |
+| G | インポート行数 |
+| H | 重複行数 |
+| I | エラーメッセージ |
 
 ## トラブルシューティング
 
-異常系の対応は `lineHandler.js` で実装済み：
+異常系の対応は各モジュールで実装済み：
 
 - 画像取得失敗 → ユーザーに通知
 - レシート解析失敗 → ユーザーに通知
 - スプレッドシート記録失敗 → ユーザーに通知
 - プロフィール取得失敗 → 「不明」として続行
-
-## 今後の拡張案
-
-- 複数画像の一括送信対応
-- 月別・ユーザー別の集計ダッシュボード
-- カテゴリー分類の自動化
-- 領収書の PDF 出力
+- CSV インポート失敗 → 「要確認」フォルダへ移動・logs に記録
 
 ---
 

--- a/conf/bank_mapping/saitamaresona.json
+++ b/conf/bank_mapping/saitamaresona.json
@@ -1,4 +1,5 @@
 {
+  "bankName": "共通口座（埼玉りそな）",
   "encoding": "shift_jis",
   "skipHeaderRow": true,
   "skipFooterRow": true,

--- a/conf/bank_mapping/saitamaresona.json
+++ b/conf/bank_mapping/saitamaresona.json
@@ -1,0 +1,15 @@
+{
+  "encoding": "shift_jis",
+  "skipHeaderRow": true,
+  "skipFooterRow": true,
+  "columns": {
+    "取引日（年）": 14,
+    "取引日（月）": 15,
+    "取引日（日）": 16,
+    "金額": 17,
+    "区分": 13,
+    "残高": 18,
+    "摘要": 19,
+    "コメント": 20
+  }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,12 +1,20 @@
-# LINE Bot API ドキュメント
+# API ドキュメント
 
-## Webhook エンドポイント
+## エンドポイント一覧
 
-### POST /webhook
+| メソッド | パス | 説明 |
+|---------|------|------|
+| POST | `/webhook` | LINE Messaging API からのイベント受信 |
+| POST | `/bank/import` | 銀行取引 CSV インポート |
+| GET | `/health` | ヘルスチェック |
+
+---
+
+## POST /webhook
 
 LINE Messaging API からのイベントを受け取ります。
 
-**リクエスト:** 
+**リクエスト:**
 
 ```
 POST https://{cloud-run-url}/webhook
@@ -14,7 +22,7 @@ Content-Type: application/json
 X-Line-Signature: {署名}
 ```
 
-**リクエストボディ：**
+**リクエストボディ:**
 
 ```json
 {
@@ -27,7 +35,6 @@ X-Line-Signature: {署名}
         "userId": "U1234567890abcdef1234567890abcd"
       },
       "replyToken": "nHuyWiB7yP5Zw52FIkcQT",
-      "timestamp": 1462629479859,
       "message": {
         "type": "image",
         "id": "100001"
@@ -39,41 +46,77 @@ X-Line-Signature: {署名}
 
 **レスポンス:**
 
-- **成功時 (200 OK):**
-  ```
-  OK
-  ```
+- `200 OK` — 受信完了（イベント処理は非同期で継続）
+- `400 Bad Request` — 不正なリクエスト形式
+- `401 Unauthorized` — 署名検証失敗
 
-- **失敗時:**
-  - `400 Bad Request` — 不正なリクエスト形式
-  - `401 Unauthorized` — 署名検証失敗
-  - `500 Internal Server Error` — サーバーエラー
+**処理フロー:**
+
+1. LINE Webhook を受け取り即座に 200 を返す（タイムアウト防止）
+2. バックグラウンドで画像解析・Sheets 記録・返信を実行
 
 ---
 
-## イベント種別
+## POST /bank/import
 
-### 画像メッセージ（処理対象）
+Google Drive の指定フォルダにある CSV ファイルを読み込み、bank trans シートにインポートします。
+
+**リクエスト:**
+
+```
+POST https://{cloud-run-url}/bank/import
+Content-Type: application/json
+```
+
+**リクエストボディ（省略可）:**
 
 ```json
 {
-  "type": "message",
-  "message": {
-    "type": "image",
-    "id": "message_id"
-  }
+  "spreadsheetId": "1V3GW_...",
+  "bankFolderId": "1abc..."
 }
 ```
 
-**処理:**
-1. メッセージID から BASE64 画像データを取得
-2. Gemini API で解析
-3. Google Sheets に記録
-4. ユーザーに返信
+省略した場合は環境変数 `SPREADSHEET_ID` / `BANK_FOLDER_ID` を使用。
 
-### その他のメッセージ
+**レスポンス（成功）:**
 
-テキスト、スタンプ、位置情報など → **無視**
+```json
+{
+  "status": "completed",
+  "message": "2ファイル成功、0ファイル失敗",
+  "timestamp": "2026/04/27 10:00:00",
+  "results": [
+    {
+      "fileName": "202604.csv",
+      "status": "success",
+      "totalRows": 42,
+      "importedRows": 40,
+      "duplicateRows": 2,
+      "errorMessage": ""
+    }
+  ]
+}
+```
+
+**レスポンス（エラー）:**
+
+```json
+{
+  "status": "error",
+  "message": "bank_mapping.json が見つかりません"
+}
+```
+
+**フォルダ構成:**
+
+```
+{BANK_FOLDER_ID}/
+├── bank_mapping.json   # マッピング設定（必須）
+├── 202604.csv          # インポート対象 CSV
+└── 処理済み/           # 成功ファイルの移動先（自動作成）
+└── 要確認/             # 失敗ファイルの移動先（自動作成）
+```
 
 ---
 
@@ -86,8 +129,10 @@ X-Line-Signature: {署名}
 
 👤 {displayName}
 🏪 {storeName}
-💴 {totalAmount} 円
+🗓 {paymentDate}
+💴 {totalAmount} 円（{paymentMethod}）
 🛒 {items}
+📝 {remarks}  ← 支払い日時が読み取れなかった場合のみ表示
 ```
 
 **例:**
@@ -96,92 +141,30 @@ X-Line-Signature: {署名}
 
 👤 田中太郎
 🏪 セブン-イレブン
-💴 1,280 円
+🗓 2026/04/10 15:32
+💴 1,280 円（現金）
 🛒 おにぎり、コーヒー、弁当
+```
+
+**支払い日時が読み取れない場合:**
+```
+✅ 記録しました！
+
+👤 田中太郎
+🏪 セブン-イレブン
+🗓 2026/04/27 10:15:33
+💴 980 円（カード）
+🛒 サンドイッチ、お茶
+📝 支払い日時はレシートから読み取れなかったため受信日時を使用
 ```
 
 ### エラー時
 
 ```
-【エラータイプ】
-- 画像の取得に失敗しました。
-- レシートの読み取りに失敗しました。
-- スプレッドシートへの記録に失敗しました。
+画像の取得に失敗しました。
+レシートの読み取りに失敗しました。
+スプレッドシートへの記録に失敗しました。
 ```
-
----
-
-## LINE グループ内での動作
-
-### グループメッセージ処理フロー
-
-```
-グループ
-  └─ ボットをメンバーとして追加
-  └─ 画像メッセージ送信
-       └─ source.type: "group"
-       └─ source.groupId: グループID
-       └─ source.userId: 送信者ID
-         ↓
-Bot が以下を実行:
-  1. getGroupMemberProfile(groupId, userId)
-     → グループ内でのユーザー表示名取得
-  2. getMessageContent(messageId)
-     → 画像データ取得
-  3. 解析・記録
-  4. replyMessage(replyToken, message)
-     → グループ内で返信
-```
-
-### ユーザー情報取得
-
-|シチュエーション | API メソッド | 取得情報 |
-|---|---|---|
-| グループ | `getGroupMemberProfile()` | グループ内の表示名 |
-| 1対1チャット | `getProfile()` | LINEプロフィール名 |
-
----
-
-## Google Sheets ス키ーマ
-
-### 追記対象範囲
-
-```
-Range: {SHEET_NAME}!A:F
-```
-
-例: `receipts!A:F`
-
-### 列定義
-
-| 列 | タイプ | 説明 | 例 |
-|----|--------|------|-----|
-| A | String | タイムスタンプ | `2026-04-10 15:30:45` |
-| B | String | LINE User ID | `U1234567890abcdef1234567890abcd` |
-| C | String | 表示名 | `田中太郎` |
-| D | String | 店名 | `セブン-イレブン新宿店` |
-| E | Number | 合計金額（円） | `1280` |
-| F | String | 品目（改行区切り） | `おにぎり 150円\nコーヒー 180円\nお菓子 320円` |
-
-### 追記時の値処理
-
-```javascript
-[
-  [
-    timestamp,           // "2026-04-10 15:30:45" (String)
-    userId,             // "U1234567890..." (String)
-    displayName,        // "田中太郎" (String)
-    storeName ?? "",    // "" if null (String)
-    totalAmount ?? "",  // "" if null (可変 - Numbers)
-    items ?? ""         // "" if null (String with newlines)
-  ]
-]
-```
-
-**注意:**
-- null 値は空文字列に変換
-- 改行は `\n` のまま保持（Sheets で複数行表示）
-- `valueInputOption: "USER_ENTERED"` で自動フォーマット
 
 ---
 
@@ -206,134 +189,102 @@ Range: {SHEET_NAME}!A:F
 {
   "storeName": "セブン-イレブン",
   "totalAmount": 1280,
+  "paymentDate": "2026/04/10 15:32",
+  "paymentMethod": "現金",
   "items": "おにぎり 150円\nサンドイッチ 300円\nコーヒー 180円"
 }
 ```
 
-### NULL値の処理
+### フィールド仕様
 
-値が読み取れない場合:
-
-```json
-{
-  "storeName": null,
-  "totalAmount": null,
-  "items": "品目リスト（テキスト）"
-}
-```
-
-アプリケーション側で `?? ""` で空文字列に統一
+| フィールド | 型 | 説明 | 読み取れない場合 |
+|-----------|-----|------|--------------|
+| `storeName` | string\|null | 店名 | null |
+| `totalAmount` | number\|null | 合計金額（税込み、円） | null |
+| `paymentDate` | string\|null | 支払い日時（YYYY/MM/DD HH:mm または YYYY/MM/DD） | null → 受信日時を使用 |
+| `paymentMethod` | string | 「現金」または「カード」 | 「現金」 |
+| `items` | string\|null | 品目リスト（改行区切り） | null |
 
 ---
 
-## エラーハンドリング
+## Google Sheets スキーマ
 
-### ユースケース別の対応
+### receipts シート（レシート記録）
 
-#### 1. プロフィール取得失敗
+追記範囲: `{SHEET_NAME}!A:J`
 
-```
-console.warn("プロフィール取得失敗:", err.message);
-displayName = "不明";  // フォールバック
-// 処理続行
-```
+| 列 | タイプ | 項目 | 例 |
+|----|--------|------|----|
+| A | String | 受信日時 | `2026/04/10 15:33:01` |
+| B | String | 支払い日時 | `2026/04/10 15:32` |
+| C | String | LINE UserID | `U1234567890abcdef...` |
+| D | String | 表示名 | `田中太郎` |
+| E | String | グループID | `C1234567890abcdef...` |
+| F | String | 店名 | `セブン-イレブン新宿店` |
+| G | Number | 合計金額（円）| `1280` |
+| H | String | 支払い方法 | `現金` |
+| I | String | 品目（改行区切り）| `おにぎり 150円\nコーヒー 180円` |
+| J | String | 備考 | `支払い日時はレシートから読み取れなかったため受信日時を使用` |
 
-#### 2. 画像取得失敗
+### bank trans シート（銀行取引）
 
-```
-console.error("画像取得失敗:", err);
-// replyMessage: "画像の取得に失敗しました。"
-// 処理終了
-```
+追記範囲: `{BANK_TRANS_SHEET_NAME}!A:H`
 
-#### 3. Gemini 解析失敗
+| 列 | タイプ | 項目 | 例 |
+|----|--------|------|----|
+| A | String | 取引日 | `2026/04/10` |
+| B | Number | 金額 | `-1280` |
+| C | String | 区分 | `支払い` |
+| D | Number | 残高 | `125000` |
+| E | String | 摘要 | `セブンイレブン新宿店` |
+| F | String | コメント | `` |
+| G | String | カテゴリ（自動）| `` |
+| H | String | 銀行名 | `共通口座（埼玉りそな）` |
 
-```
-console.error("レシート解析失敗:", err);
-// replyMessage: "レシートの読み取りに失敗しました。"
-// 処理終了
-```
+### logs シート（インポート処理ログ）
 
-#### 4. Sheets 記録失敗
+追記範囲: `{LOGS_SHEET_NAME}!A:I`
 
-```
-console.error("スプレッドシート記録失敗:", err);
-// replyMessage: "スプレッドシートへの記録に失敗しました。"
-// 処理終了
-```
+| 列 | タイプ | 項目 | 例 |
+|----|--------|------|----|
+| A | String | タイムスタンプ | `2026/04/27 10:00:00` |
+| B | String | 処理名 | `bank trans` |
+| C | String | 銀行名 | `共通口座（埼玉りそな）` |
+| D | String | ファイル名 | `202604.csv` |
+| E | String | ステータス | `success` |
+| F | Number | 総行数 | `42` |
+| G | Number | インポート行数 | `40` |
+| H | Number | 重複行数 | `2` |
+| I | String | エラーメッセージ | `` |
+
+---
+
+## LINE グループ内での動作
+
+### ユーザー情報取得
+
+| シチュエーション | API メソッド | 取得情報 |
+|---|---|---|
+| グループ | `getGroupMemberProfile(groupId, userId)` | グループ内の表示名 |
+| 1対1チャット | `getProfile(userId)` | LINE プロフィール名 |
 
 ---
 
 ## レート制限
 
-### LINE Messaging API
+### Gemini API（Free tier）
 
-| 操作 | レート制限 |
-|------|----------|
-| メッセージ送信 | 無制限（Reply は無料） |
-| メッセージコンテンツ取得 | 無制限 |
-| メンバープロフィール取得 | 無制限 |
-
-### Gemini API（無料枠）
-
-```
-15 RPM (Requests Per Minute)
-1,500 RPD (Requests Per Day)
-
-月間上限なし
-```
-
-**1グループ 100人 × 20 画像/日 = 2,000 req/日 → 超過**
-
-調整方法:
-- 無料から有料プランへ移行
-- Vision API 切り替え（$1.5/1K）
-- リクエスト数を削減
+| 指標 | 上限 |
+|------|------|
+| RPM（リクエスト/分）| 5 |
+| TPM（トークン/分）| 250,000 |
+| RPD（リクエスト/日）| 20 |
 
 ### Google Sheets API
 
 ```
 600 リクエスト/分 (per project)
 ```
-
-現在の実装では 1リクエスト/メッセージなので問題なし
-
----
-
-## ローカルテスト
-
-### ngrok で LINE Webhook を模擬
-
-```bash
-# ターミナル 1: ngrok 起動
-ngrok http 8080
-
-# Forwarding: https://xxxx-mmmm-nn.ngrok.io → http://localhost:8080
-
-# ターミナル 2: アプリ起動
-npm run dev
-
-# LINE Developers Console で Webhook URL を更新
-# https://xxxx-mmmm-nn.ngrok.io/webhook
-```
-
-### テストリクエスト例
-
-```bash
-curl -X POST https://xxxx-mmmm-nn.ngrok.io/webhook \
-  -H "Content-Type: application/json" \
-  -H "X-Line-Signature: {signature}" \
-  -d '{
-    "events": [{
-      "type": "message",
-      "source": {"type": "user", "userId": "U..."},
-      "replyToken": "nHuyWiB7yP...",
-      "message": {"type": "image", "id": "100001"}
-    }]
-  }'
-```
-
-**注:** 本来の署名は LINE が生成するので、実際には LINE アプリから画像を送るのが簡単
 
 ---
 
@@ -347,16 +298,19 @@ curl -X POST https://xxxx-mmmm-nn.ngrok.io/webhook \
 
 ### "Hmac signature does not match"
 
-- Webhook 署名検証失敗
-- Channel Secret が間違っている可能性
+- Webhook 署名検証失敗 → Channel Secret が間違っている可能性
 
 ### スプレッドシートに記録されない
 
 - サービスアカウントがシートの編集権限を持つか確認
 - Spreadsheet ID / Sheet Name が正しいか確認
 
-### Gemini が "invalid_request_error"
+### Gemini 429 エラー
 
-- API キーが無効
-- 画像フォーマットが対応していない（JPEG/PNG 推奨）
-- Base64 エンコードの誤り
+- Free tier の RPD（20件/日）を超過している可能性
+- AI Studio の Rate Limit ページで使用量を確認: https://aistudio.google.com/app/rate-limit
+
+### bank/import でファイルが見つからない
+
+- `bank_mapping.json` がフォルダ直下に配置されているか確認
+- サービスアカウントに Drive の閲覧・編集権限があるか確認

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,6 @@
 │            (Event Webhook Endpoint)                         │
 └──────────────────────────┬──────────────────────────────────┘
                            │ webhook POST
-                           │ {type: "message", message: {type: "image"}}
                            │
         ┌──────────────────▼──────────────────┐
         │   Cloud Run                         │
@@ -22,54 +21,35 @@
         │                                      │
         │  ┌─────────────────────────────┐   │
         │  │  Express Server (Port 8080) │   │
-        │  │  - /webhook (POST)          │   │
-        │  │  - /health (GET)            │   │
-        │  └────────┬────────────────────┘   │
-        │           │                        │
-        │  ┌────────▼──────┐                │
-        │  │ lineHandler   │                │
-        │  ├───────────────┤                │
-        │  │ • Image取得   │                │
-        │  │ • User情報取得 │                │
-        │  │ • orchestrate │                │
-        │  └────────┬──────┘                │
-        │           │                        │
-        │  ┌────────┼──────────────────┐    │
-        │  │        │                  │    │
-        │  ▼        ▼                  ▼    │
-        │┌──────┐ ┌──────────────┐ ┌──────┐│
-        ││Gemini│ │Google Sheets │ │  LINE││
-        ││ API  │ │    API       │ │ Reply││
-        │└──────┘ └──────────────┘ └──────┘│
-        └──────────────────────────────────┘
-                    ▲         ▲         ▲
-         ┌──────────┘         │         └──────────┐
-         │                    │                    │
-    ┌────▼─────┐         ┌────▼─────┐        ┌────▼─────┐
-    │  Gemini  │         │ Google   │        │   LINE   │
-    │   1.5    │         │ Sheets   │        │Messaging│
-    │ Flash    │         │  API     │        │   API    │
-    │          │         │          │        │          │
-    │ Receipt  │         │ Append   │        │  Reply   │
-    │ Analysis │         │  Rows    │        │ Message  │
-    └───┬──────┘         └──────────┘        └──────────┘
-        │
-        │ Image (Base64)
-        │
-   ┌────▼──────────────┐
-   │  LINE Bot         │
-   │  (getMessageContent)
-   └───────────────────┘
+        │  │  - /webhook    (POST)       │   │
+        │  │  - /bank/import (POST)      │   │
+        │  │  - /health     (GET)        │   │
+        │  └────────┬──────────┬─────────┘   │
+        │           │          │              │
+        │  ┌────────▼──────┐  ┌▼──────────────────────────┐  │
+        │  │ lineHandler   │  │ bankTransactionImporter    │  │
+        │  ├───────────────┤  ├────────────────────────────┤  │
+        │  │ • Image 取得  │  │ • CSV 取得 (Drive)         │  │
+        │  │ • User 情報   │  │ • CSV パース               │  │
+        │  │ • orchestrate │  │ • 重複チェック             │  │
+        │  └────────┬──────┘  │ • Sheets 追記             │  │
+        │           │         │ • ログ記録                 │  │
+        │  ┌────────┼──────────────────────────────┐      │  │
+        │  ▼        ▼        ▼           ▼          ▼      │  │
+        │ Gemini  Sheets   Drive       Sheets     Sheets   │  │
+        │  API    (receipts) API     (bank trans) (logs)   │  │
+        └────────────────────────────────────────────────┘
 ```
 
 ## コンポーネント詳細
 
 ### 1. Cloud Run (Express Server)
 
-**役割:** LINE Webhook を受け取り、各サービスを調整
+**役割:** LINE Webhook と銀行インポートリクエストを受け取り、各サービスを調整
 
 **エンドポイント:**
 - `POST /webhook` — LINE のイベント受信（middleware で署名検証）
+- `POST /bank/import` — 銀行取引 CSV インポート
 - `GET /health` — ヘルスチェック
 
 **環境変数:**
@@ -78,16 +58,21 @@ LINE_CHANNEL_SECRET          # Webhook 署名検証用
 LINE_CHANNEL_ACCESS_TOKEN    # メッセージ送受信
 GEMINI_API_KEY               # Gemini API 認証
 SPREADSHEET_ID               # Google Sheets ID
-SHEET_NAME                   # シート名（default: receipts）
+SHEET_NAME                   # receipts シート名（default: receipts）
+BANK_TRANS_SHEET_NAME        # 銀行取引シート名（default: bank trans）
+LOGS_SHEET_NAME              # ログシート名（default: logs）
+BANK_FOLDER_ID               # 銀行 CSV を置く Google Drive フォルダ ID
 GOOGLE_SERVICE_ACCOUNT_JSON  # GCP サービスアカウント認証情報
 ```
+
+---
 
 ### 2. LINE Handler (`src/lineHandler.js`)
 
 **フロー:**
 
 ```
-Event受信
+Event 受信
   ↓
 [メッセージタイプ判定]
   ├─ 画像以外 → 無視して終了
@@ -103,174 +88,119 @@ Event受信
       ↓
   [Gemini で解析]
       └─ parseReceipt(imageBuffer)
+            → {storeName, totalAmount, paymentDate, paymentMethod, items}
+      ↓
+  [支払い日時フォールバック]
+      └─ paymentDate が null → 受信日時を使用、備考にメモ
       ↓
   [Sheets に記録]
-      └─ logToSheet({timestamp, userId, displayName, storeName, totalAmount, items})
+      └─ logToSheet({receivedAt, paymentDate, userId, displayName,
+                      groupId, storeName, totalAmount, paymentMethod, items, remarks})
       ↓
   [返信を送信]
       └─ replyMessage(replyToken, text)
 ```
 
-**エラーハンドリング:**
-
-各ステップでエラーキャッチ → ユーザーに通知して続行
-
-```javascript
-try {
-  profile = await client.getGroupMemberProfile(groupId, userId);
-} catch (err) {
-  console.warn(`プロフィール取得失敗: ${err.message}`);
-  displayName = "不明";  // フォールバック
-}
-```
+---
 
 ### 3. Gemini Parser (`src/geminiParser.js`)
 
-**入力:** レシート画像（Binary）
+**モデル:** Gemini 2.5 Flash
 
-**プロセス:**
+**入力:** レシート画像（Buffer）
 
-```
-画像 (JPEG/PNG)
-  ↓
-[Base64 エンコード]
-  ↓
-Gemini 1.5 Flash に送信
-  ├─ プロンプト: レシート解析指示
-  ├─ 画像データ (inlineData)
-  └─ 出力形式: JSON
-  ↓
-[JSON パース]
-  ↓
-構造化データ返却
+**出力:**
+```json
 {
   "storeName": "セブン-イレブン",
   "totalAmount": 1280,
+  "paymentDate": "2026/04/10 15:32",
+  "paymentMethod": "現金",
   "items": "おにぎり 150円\nコーヒー 180円\n..."
 }
 ```
 
-**Prompt:**
+**paymentMethod のルール:**
+- クレジット・デビット・電子マネー・QR決済 → 「カード」
+- 判断できない場合 → 「現金」
 
-```
-この画像はレシートです。以下の情報をJSON形式で抽出してください。
-情報が読み取れない場合は null にしてください。
-
-{
-  "storeName": "店名（文字列）",
-  "totalAmount": 合計金額（数値、税込み、円記号なし）,
-  "items": "品目リスト（各行に「品名 金額円」の形式で改行区切り）"
-}
-```
-
-**費用概算（月 100 件）:**
-- Gemini 1.5 Flash: $0.075/1K トークン
-- 1 リクエスト平均 ~600 トークン
-- 100 × 600 / 1000 × $0.075 = $4.5 ＝ 約 ¥650
-
-**品質:** 
-- テクスト認識精度: ~95%（一般的なレシート）
-- 構造化精度: ~85%（複雑な書きとめはミス可能性あり）
+---
 
 ### 4. Sheets Logger (`src/sheetsLogger.js`)
 
-**認証:** Google Cloud Service Account
+**receipts シートのレコード形式:**
 
-```
-┌─────────────────┐
-│  Service      │
-│  Account      │──────→ Sheets API
-│  (JSON Key)   │
-└─────────────────┘
-     JSON ↓
-credentials.json から GoogleAuth オブジェクト作成
-     ↓
-google.sheets.spreadsheets.values.append()
-```
-
-**レコード形式:**
-
-| A | B | C | D | E | F |
-|---|---|---|---|---|---|
-| 日時 | LINE UserID | 表示名 | 店名 | 合計金額 | 品目 |
-| 2026-04-10 15:32 | U1234abcd... | 田中太郎 | セブン-イレブン | 1280 | おにぎり 150円<br>コーヒー 180円 |
-
-**追記方法:**
-
-```javascript
-await sheets.spreadsheets.values.append({
-  spreadsheetId: SPREADSHEET_ID,
-  range: `receipts!A:F`,
-  valueInputOption: "USER_ENTERED",  // 数式や日時フォーマットを解釈
-  insertDataOption: "INSERT_ROWS",   // 既存データを上に移動しない
-  requestBody: { values: [[...]] }
-});
-```
+| A | B | C | D | E | F | G | H | I | J |
+|---|---|---|---|---|---|---|---|---|---|
+| 受信日時 | 支払い日時 | LINE UserID | 表示名 | グループID | 店名 | 合計金額 | 支払い方法 | 品目 | 備考 |
 
 ---
 
-## データフロー例
+### 5. 銀行取引インポート
 
-### シナリオ: グループでレシートを共有
+#### フロー
 
 ```
-[グループ]
-田中太郎が画像送信
+POST /bank/import
   ↓
-[LINE Bot]
-EVENT: message.image
-  ├─ groupId: "C12345..."
-  ├─ userId: "U5678..."
-  └─ imageId: "12345..."
+[マッピング設定読み込み]
+  └─ Google Drive: bank_mapping.json
+        → {bankName, encoding, skipHeaderRow, skipFooterRow, columns}
   ↓
-[lineHandler]
-getGroupMemberProfile("C12345...", "U5678...") → "田中太郎"
-getMessageContent("12345...") → Buffer (JPEG)
+[CSV ファイル一覧取得]
+  └─ bankDriveHelper: listCsvFiles(folderId)
   ↓
-[geminiParser]
-Gemini: "この店はファミリーマート、¥2,450, 弁当¥580..." → JSON
+[既存トランザクション取得]
+  └─ bankTransactionDedup: getExistingTransactions(spreadsheetId)
   ↓
+[各 CSV ファイルを処理]
+  ├─ ダウンロード (Drive)
+  ├─ パース (bankCsvParser)
+  │    ├─ Shift-JIS デコード (iconv-lite)
+  │    ├─ 半角カナ→全角変換
+  │    └─ NFC 正規化
+  ├─ 重複チェック (bankTransactionDedup)
+  ├─ Sheets 追記 (bank trans シート)
+  ├─ ファイル移動 (成功→処理済み / 失敗→要確認)
+  └─ ログ記録 (logs シート)
+```
+
+#### bank trans シートのレコード形式
+
+| A | B | C | D | E | F | G | H |
+|---|---|---|---|---|---|---|---|
+| 取引日 | 金額 | 区分 | 残高 | 摘要 | コメント | カテゴリ（自動）| 銀行名 |
+
+#### logs シートのレコード形式
+
+| A | B | C | D | E | F | G | H | I |
+|---|---|---|---|---|---|---|---|---|
+| タイムスタンプ | 処理名 | 銀行名 | ファイル名 | ステータス | 総行数 | インポート行数 | 重複行数 | エラー |
+
+#### マッピング設定ファイル（`bank_mapping.json`）
+
+銀行フォルダに配置する JSON ファイル。銀行ごとに CSV の列構成を定義する。
+
+```json
 {
-  storeName: "ファミリーマート",
-  totalAmount: 2450,
-  items: "弁当 580円\nおかし 320円\nドリンク 240円"
+  "bankName": "埼玉りそな銀行",
+  "encoding": "shift_jis",
+  "skipHeaderRow": true,
+  "skipFooterRow": true,
+  "columns": {
+    "取引日（年）": 14,
+    "取引日（月）": 15,
+    "取引日（日）": 16,
+    "金額": 17,
+    "区分": 13,
+    "残高": 18,
+    "摘要": 19,
+    "コメント": 20
+  }
 }
-  ↓
-[sheetsLogger]
-Sheets.append({
-  timestamp: "2026-04-10 15:45",
-  userId: "U5678...",
-  displayName: "田中太郎",
-  storeName: "ファミリーマート",
-  totalAmount: 2450,
-  items: "弁当 580円\nおかし 320円\n..."
-})
-  ↓
-[LINE Bot]
-replyMessage(replyToken, "✅ 記録しました！...")
-  ↓
-[グループ]
-ボットの返信が表示される
 ```
 
----
-
-## スケーラビリティ
-
-### 現在の設定での処理能力
-
-| 指標 | 上限 | 説明 |
-|------|------|------|
-| Cloud Run 並行実行 | 80個 | デフォルト（無料枠内） |
-| Gemini API | 1,500 req/日 | 無料枠 |
-| Sheets API | 600 req/分 | API 仕様上の制限 |
-| **推定処理能力** | **1,500 img/日** | Gemini が律速 |
-
-### 月 5,000 件の場合（拡張必要）
-
-Gemini API から Vision API へ切り替え可能：
-- Vision API: $1.5/1K リクエスト → 月額 $7.5
-- Gemini より安いが、結果は JSON でなくテキスト
+取引日は単一カラム（`"取引日": 0`）でも年月日分割（`"取引日（年）"`, `"取引日（月）"`, `"取引日（日）"`）でも対応。
 
 ---
 
@@ -279,7 +209,6 @@ Gemini API から Vision API へ切り替え可能：
 ### LINE Webhook 署名検証
 
 ```javascript
-// Express middleware で自動検証（@line/bot-sdk）
 app.post("/webhook", middleware(config), handler);
 // X-Line-Signature ヘッダーが不正な場合は 401 返す
 ```
@@ -287,35 +216,29 @@ app.post("/webhook", middleware(config), handler);
 ### サービスアカウント認証
 
 ```javascript
-// JSON キーから GoogleAuth インスタンス作成
 new google.auth.GoogleAuth({
   credentials: JSON.parse(GOOGLE_SERVICE_ACCOUNT_JSON),
-  scopes: ["https://www.googleapis.com/auth/spreadsheets"]
+  scopes: [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive"
+  ]
 })
 ```
 
 **ベストプラクティス:**
 - ✅ JSON キーは環境変数に（コミットしない）
 - ✅ Cloud Run のサービスアカウントに最小権限を付与
-- ✅ Sheets の共有を「編集者」のみに限定
+- ✅ Sheets / Drive の共有を「編集者」のみに限定
 
 ---
 
-## 監視・ロギング
+## スケーラビリティ
 
-### Cloud Run ログ
-
-```bash
-gcloud run logs read receipt-log-bot --region asia-northeast1 --limit 50
-```
-
-### アプリケーションログ
-
-```javascript
-console.log("レシート記録完了:", storeName);
-console.warn("プロフィール取得失敗:", err.message);
-console.error("Gemini API エラー:", err);
-```
+| 指標 | 上限 | 説明 |
+|------|------|------|
+| Cloud Run 並行実行 | 80個 | デフォルト（無料枠内） |
+| Gemini API (Free) | 20 req/日 | 無料枠 |
+| Sheets API | 600 req/分 | API 仕様上の制限 |
 
 ---
 
@@ -324,7 +247,6 @@ console.error("Gemini API エラー:", err);
 1. **Cloud Run:**
    - メモリ: 512 MB（デフォルト OK）
    - タイムアウト: 60秒（Gemini 待ち時間を考慮）
-   - 並行実行: 80（デフォルト OK）
 
 2. **エラー通知:**
    - Cloud Logging に ERROR を集約
@@ -332,5 +254,3 @@ console.error("Gemini API エラー:", err);
 
 3. **バージョン管理:**
    - Git タグで本番版を明記
-   - Dockerfile レジストリ: Artifact Registry 推奨
-

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -6,7 +6,7 @@
 receipt-log/
 ├── src/
 │   ├── index.js
-│   │   └─ Express サーバー、Webhook エンドポイント
+│   │   └─ Express サーバー、/webhook・/bank/import エンドポイント
 │   │
 │   ├── lineHandler.js
 │   │   ├─ LINE イベント処理
@@ -15,33 +15,51 @@ receipt-log/
 │   │   └─ orchestration & error handling
 │   │
 │   ├── geminiParser.js
-│   │   └─ Gemini 1.5 Flash を使用したレシート解析
-│   │       入力: Buffer | 出力: {storeName, totalAmount, items}
+│   │   └─ Gemini 2.5 Flash を使用したレシート解析
+│   │       入力: Buffer | 出力: {storeName, totalAmount, paymentDate, paymentMethod, items}
 │   │
-│   └── sheetsLogger.js
-│       └─ サービスアカウント認証で Google Sheets に追記
-│           範囲: {SHEET_NAME}!A:F
+│   ├── sheetsLogger.js
+│   │   └─ サービスアカウント認証で receipts シートに追記
+│   │       範囲: {SHEET_NAME}!A:J
+│   │
+│   ├── bankTransactionImporter.js
+│   │   └─ 銀行取引インポートのオーケストレーション
+│   │       Drive から CSV 取得 → パース → 重複チェック → Sheets 追記
+│   │
+│   ├── bankCsvParser.js
+│   │   └─ CSV パース（Shift-JIS 対応、半角カナ全角変換、NFC 正規化）
+│   │       マッピング設定 (bank_mapping.json) を使用して列を抽出
+│   │
+│   ├── bankTransactionDedup.js
+│   │   └─ 既存トランザクションとの重複チェック
+│   │       照合キー: 取引日 + 金額 + 摘要 + 残高
+│   │
+│   ├── bankDriveHelper.js
+│   │   └─ Google Drive から CSV 一覧取得・ダウンロード・フォルダ移動
+│   │
+│   └── logger.js
+│       └─ logs シートへの処理結果記録
+│           範囲: {LOGS_SHEET_NAME}!A:I
+│
+├── conf/
+│   └── bank_mapping/
+│       └── saitamaresona.json   # 銀行マッピングサンプル
 │
 ├── package.json
-│   └─ 依存関係（@line/bot-sdk, googleapis, @google/generative-ai）
+│   └─ 依存関係（@line/bot-sdk, googleapis, @google/generative-ai, iconv-lite）
 │
 ├── Dockerfile
 │   └─ Cloud Run デプロイ用（Node 20-slim）
 │
-├── README.md
-│   └─ プロジェクト概要
+├── .env.example
+│   └─ 環境変数テンプレート
 │
-├── ARCHITECTURE.md
-│   └─ システム設計（フロー、アーキテクチャ、スキーマ）
-│
-├── API.md
-│   └─ Webhook / LINE API / Sheets API 仕様
-│
-├── SETUP.md
-│   └─ GCP プロジェクト作成からデプロイまで
-│
-└── .env.example
-    └─ 環境変数テンプレート
+└── docs/
+    ├── SETUP.md       # GCP プロジェクト作成からデプロイまで
+    ├── ARCHITECTURE.md  # システム設計
+    ├── API.md         # Webhook / Sheets スキーマ / エンドポイント仕様
+    ├── QUICKREF.md    # このファイル
+    └── MONITORING.md  # 監視・運用手順
 ```
 
 ---
@@ -52,9 +70,12 @@ receipt-log/
 |------|------|--------|
 | `LINE_CHANNEL_SECRET` | LINE Webhook 署名検証 | LINE Developers > Channel Secret |
 | `LINE_CHANNEL_ACCESS_TOKEN` | LINE メッセージ送受信 | LINE Developers > Channel Access Token |
-| `GEMINI_API_KEY` | Gemini API 認証 | Google AI Studio (aistudio.google.com) |
+| `GEMINI_API_KEY` | Gemini API 認証 | Google AI Studio (aistudio.google.com) ※個人アカウント |
 | `SPREADSHEET_ID` | Google Sheets ID | URL: `/d/{SpreadsheetID}/edit` |
-| `SHEET_NAME` | シート名（デフォルト: receipts） | Google Sheets タブ名 |
+| `SHEET_NAME` | receipts シート名（default: receipts）| Google Sheets タブ名 |
+| `BANK_TRANS_SHEET_NAME` | 銀行取引シート名（default: bank trans）| Google Sheets タブ名 |
+| `LOGS_SHEET_NAME` | ログシート名（default: logs）| Google Sheets タブ名 |
+| `BANK_FOLDER_ID` | 銀行 CSV フォルダ ID | Drive の URL: `/folders/{ID}` |
 | `GOOGLE_SERVICE_ACCOUNT_JSON` | GCP サービスアカウント認証 | gcloud iam service-accounts keys create |
 
 ---
@@ -67,11 +88,11 @@ receipt-log/
 # 1. 依存関係のインストール
 npm install
 
-# 2. .env ファイル作成
-cp .env.example .env
+# 2. .env.local ファイル作成
+cp .env.example .env.local
 # 値を埋める...
 
-# 3. ローカル実行
+# 3. ローカル実行（.env.local を自動で読み込む）
 npm run dev
 ```
 
@@ -88,12 +109,10 @@ gcloud run logs read receipt-log-bot --region asia-northeast1 --limit 50
 ### デプロイ
 
 ```bash
-# 環境変数を指定してデプロイ（SETUP.md 参照）
 gcloud run deploy receipt-log-bot \
   --source . \
   --region asia-northeast1 \
-  --set-env-vars="..." \
-  # ... 他の環境変数
+  --set-env-vars="..." # SETUP.md 参照
 ```
 
 ---
@@ -124,42 +143,43 @@ await client.replyMessage(replyToken, { type: "text", text: "..." });
 ```javascript
 const { GoogleGenerativeAI } = require("@google/generative-ai");
 const genAI = new GoogleGenerativeAI(apiKey);
-const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
 
-// 画像 + テキスト送信
 const result = await model.generateContent([
   prompt,
-  {
-    inlineData: {
-      data: imageBuffer.toString("base64"),
-      mimeType: "image/jpeg"
-    }
-  }
+  { inlineData: { data: imageBuffer.toString("base64"), mimeType: "image/jpeg" } }
 ]);
-
-// レスポンス取得
 const text = result.response.text();
 ```
 
-### Google Sheets API
+### Google Sheets API（追記）
 
 ```javascript
 const { google } = require("googleapis");
 const sheets = google.sheets({ version: "v4", auth });
 
-// 行を追記
 await sheets.spreadsheets.values.append({
   spreadsheetId,
-  range: `${SHEET_NAME}!A:F`,
+  range: `${SHEET_NAME}!A:J`,   // receipts: A:J / bank trans: A:H / logs: A:I
   valueInputOption: "USER_ENTERED",
   insertDataOption: "INSERT_ROWS",
   requestBody: { values: [[...]] }
 });
 ```
 
+### 銀行インポートのローカルテスト
+
+```bash
+curl -X POST http://localhost:8080/bank/import \
+  -H "Content-Type: application/json" \
+  -d '{"spreadsheetId": "...", "bankFolderId": "..."}'
+```
+
 ---
 
 ## エラー対応フローチャート
+
+### レシート処理（/webhook）
 
 ```
 Webhook 受信
@@ -183,15 +203,36 @@ Webhook 受信
      └─► replyMessage("✅ 記録しました！...") → 終了
 ```
 
+### 銀行インポート（/bank/import）
+
+```
+POST /bank/import
+  │
+  ├─ bank_mapping.json が見つからない → 400 エラー
+  ├─ CSV ファイルなし → "処理対象なし" で 200
+  │
+  └─ 各 CSV ファイル
+      ├─ パース失敗 → 「要確認」フォルダへ移動・logs に記録
+      └─ 成功 → 「処理済み」フォルダへ移動・logs に記録
+```
+
 ---
 
 ## テストチェックリスト
 
-- [ ] ローカルで `npm run dev` が起動する
+### レシート機能
+- [ ] `npm run dev` が起動する
 - [ ] ngrok で LINE テストメッセージ送信 → Bot 返信確認
-- [ ] Google Sheets に行が追記されることを確認
-- [ ] グループのユーザー ID が記録される
-- [ ] エラー時に Bot が通知を返す
+- [ ] receipts シートに行が追記される（A:J 全カラム）
+- [ ] 支払い日時が読み取れない場合、J 列に備考が入る
+- [ ] グループ ID が E 列に記録される
+
+### 銀行インポート機能
+- [ ] `POST /bank/import` でエラーなく完了する
+- [ ] bank trans シートに行が追記される（H 列に銀行名）
+- [ ] logs シートに処理結果が記録される（B 列に "bank trans"、C 列に銀行名）
+- [ ] 重複行が除外される
+- [ ] 処理済み CSV が「処理済み」フォルダへ移動する
 
 ---
 
@@ -205,74 +246,4 @@ Webhook 受信
 | Sheets 追記 | ~100ms |
 | **合計** | **~2.2-5.2s** |
 
-タイムアウト: Cloud Run 60秒（充分な余裕）
-
----
-
-## メトリクス監視
-
-### 重要な KPI
-
-```
-Error Rate (1日)
-  └─ replyMessage("失敗しました") の頻度
-  └─ 目安: < 1%
-
-Latency P95
-  └─ Webhook 完了まで
-  └─ 目安: < 5秒
-
-Daily Requests
-  └─ Gemini API 使用量
-  └─ 目安: < 1,500 (無料枠)
-```
-
-### Cloud Logging で監視（オプション）
-
-```bash
-# エラーログだけを抽出
-gcloud run logs read receipt-log-bot \
-  --region asia-northeast1 \
-  --filter="severity>=ERROR"
-
-# 特定の期間で集計
-gcloud run logs read receipt-log-bot \
-  --region asia-northeast1 \
-  --limit 100 \
-  --from-log-name=projects/PROJECT_ID/logs/run.googleapis.com%2Fstdout
-```
-
----
-
-## よくある問題と解決策
-
-### Q: Sheets に記録されない
-**A:**
-1. Spreadsheet ID が正しいか確認
-2. サービスアカウントがシートの共有を持つか確認
-   ```bash
-   gcloud iam service-accounts describe receipt-bot-sa@PROJECT_ID.iam.gserviceaccount.com
-   ```
-3. `gcloud run logs` でエラーを確認
-
-### Q: Bot の返信が遅い
-**A:**
-1. Gemini API レート制限を確認（15 RPM）
-2. 大きな画像を送っていないか確認
-3. Cloud Run メモリを増やす（デフォルト 512 MB で充分）
-
-### Q: グループで「不明」と表示される
-**A:**
-1. Bot がグループに参加しているか確認
-2. グループ ID が正しく渡されているか確認
-3. `console.warn("プロフィール取得失敗")` をログで見てフォールバック動作は正常
-
----
-
-## まとめ
-
-- **3 つのサービス統合:** LINE + Gemini + Google Sheets
-- **エラーハンドリング:** 各ステップで try-catch、段階的フェイルセーフ
-- **スケーラビリティ:** 無料枠で月 1,500 件まで対応可能
-- **監視:** Cloud Logging で自動ログ、エラー時は Slack 通知可能（拡張）
-
+タイムアウト: Cloud Run 60秒（十分な余裕）

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@line/bot-sdk": "^9.4.0",
         "dotenv": "^17.4.2",
         "express": "^4.21.2",
-        "googleapis": "^144.0.0"
+        "googleapis": "^144.0.0",
+        "iconv-lite": "^0.7.2"
       },
       "engines": {
         "node": ">=20"
@@ -174,6 +175,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -798,15 +811,19 @@
       "license": "MIT"
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -1112,6 +1129,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@line/bot-sdk": "^9.4.0",
     "dotenv": "^17.4.2",
     "express": "^4.21.2",
-    "googleapis": "^144.0.0"
+    "googleapis": "^144.0.0",
+    "iconv-lite": "^0.7.2"
   }
 }

--- a/src/bankCsvParser.js
+++ b/src/bankCsvParser.js
@@ -42,7 +42,7 @@ async function loadBankMapping(bankFolderId) {
 /**
  * CSVをパースしてオブジェクト配列に変換
  * @param {Buffer} csvBuffer - CSVファイルの内容
- * @param {Object} mapping - マッピング設定 { columns: { "取引日": 0, "金額": 1, ... } }
+ * @param {Object} mapping - マッピング設定 { skipHeaderRow: true/false, skipFooterRow: true/false, columns: { "取引日": 0, ... } }
  * @returns {Array<Object>} パース済みのトランザクションリスト
  */
 function parseCSV(csvBuffer, mapping) {
@@ -58,8 +58,9 @@ function parseCSV(csvBuffer, mapping) {
   // 最初の行をヘッダーとして処理するか、列インデックスで処理するか
   // マッピングで列インデックスが指定されているため、全行がデータ
   const startIndex = mapping.skipHeaderRow ? 1 : 0;
+  const endIndex = mapping.skipFooterRow ? lines.length - 1 : lines.length;
 
-  for (let i = startIndex; i < lines.length; i++) {
+  for (let i = startIndex; i < endIndex; i++) {
     const values = parseCSVLine(lines[i]);
     const transaction = extractTransactionData(values, mapping.columns);
 
@@ -108,8 +109,24 @@ function parseCSVLine(line) {
  * @returns {Object|null} トランザクションオブジェクト
  */
 function extractTransactionData(values, columns) {
-  // 必須フィールド
-  const transactionDate = values[columns["取引日"]]?.trim();
+  // 取引日を取得（単一カラムまたは複合カラム）
+  let transactionDate;
+  if (columns["取引日"] !== undefined) {
+    transactionDate = values[columns["取引日"]]?.trim();
+  } else if (
+    columns["取引日（年）"] !== undefined &&
+    columns["取引日（月）"] !== undefined &&
+    columns["取引日（日）"] !== undefined
+  ) {
+    const year = values[columns["取引日（年）"]]?.trim();
+    const month = values[columns["取引日（月）"]]?.trim();
+    const day = values[columns["取引日（日）"]]?.trim();
+
+    if (year && month && day) {
+      transactionDate = `${year}/${month}/${day}`;
+    }
+  }
+
   const amount = values[columns["金額"]]?.trim();
   const description = values[columns["摘要"]]?.trim();
   const balance = values[columns["残高"]]?.trim();

--- a/src/bankCsvParser.js
+++ b/src/bankCsvParser.js
@@ -201,7 +201,8 @@ function convertHankakuToZenkaku(text) {
   result = result.replace(/ﾍﾟ/g, "ペ");
   result = result.replace(/ﾎﾟ/g, "ポ");
 
-  return result;
+  // NFC正規化で長音符や複合文字を正規化
+  return result.normalize("NFC");
 }
 
 /**

--- a/src/bankCsvParser.js
+++ b/src/bankCsvParser.js
@@ -1,4 +1,5 @@
 const { downloadFile } = require("./bankDriveHelper");
+const iconv = require("iconv-lite");
 
 const MAPPING_FILENAME = "bank_mapping.json";
 
@@ -42,11 +43,13 @@ async function loadBankMapping(bankFolderId) {
 /**
  * CSVをパースしてオブジェクト配列に変換
  * @param {Buffer} csvBuffer - CSVファイルの内容
- * @param {Object} mapping - マッピング設定 { skipHeaderRow: true/false, skipFooterRow: true/false, columns: { "取引日": 0, ... } }
+ * @param {Object} mapping - マッピング設定 { skipHeaderRow: true/false, skipFooterRow: true/false, encoding: "utf-8" | "shift_jis", columns: { "取引日": 0, ... } }
  * @returns {Array<Object>} パース済みのトランザクションリスト
  */
 function parseCSV(csvBuffer, mapping) {
-  const csv = csvBuffer.toString("utf-8");
+  // エンコーディングに対応（デフォルトはutf-8）
+  const encoding = mapping.encoding || "utf-8";
+  const csv = iconv.decode(csvBuffer, encoding);
   const lines = csv.split("\n").filter((line) => line.trim());
 
   if (lines.length === 0) {
@@ -103,6 +106,105 @@ function parseCSVLine(line) {
 }
 
 /**
+ * 半角カナを全角カナに変換
+ * @param {string} text - 変換対象のテキスト
+ * @returns {string} 全角カナに変換されたテキスト
+ */
+function convertHankakuToZenkaku(text) {
+  if (!text) return text;
+
+  // 半角カナから全角カナへのマッピング
+  const hankakuMap = {
+    ｱ: "ア",
+    ｲ: "イ",
+    ｳ: "ウ",
+    ｴ: "エ",
+    ｵ: "オ",
+    ｶ: "カ",
+    ｷ: "キ",
+    ｸ: "ク",
+    ｹ: "ケ",
+    ｺ: "コ",
+    ｻ: "サ",
+    ｼ: "シ",
+    ｽ: "ス",
+    ｾ: "セ",
+    ｿ: "ソ",
+    ﾀ: "タ",
+    ﾁ: "チ",
+    ﾂ: "ツ",
+    ﾃ: "テ",
+    ﾄ: "ト",
+    ﾅ: "ナ",
+    ﾆ: "ニ",
+    ﾇ: "ヌ",
+    ﾈ: "ネ",
+    ﾉ: "ノ",
+    ﾊ: "ハ",
+    ﾋ: "ヒ",
+    ﾌ: "フ",
+    ﾍ: "ヘ",
+    ﾎ: "ホ",
+    ﾏ: "マ",
+    ﾐ: "ミ",
+    ﾑ: "ム",
+    ﾒ: "メ",
+    ﾓ: "モ",
+    ﾔ: "ヤ",
+    ﾕ: "ユ",
+    ﾖ: "ヨ",
+    ﾗ: "ラ",
+    ﾘ: "リ",
+    ﾙ: "ル",
+    ﾚ: "レ",
+    ﾛ: "ロ",
+    ﾜ: "ワ",
+    ﾝ: "ン",
+    ｧ: "ァ",
+    ｨ: "ィ",
+    ｩ: "ゥ",
+    ｪ: "ェ",
+    ｫ: "ォ",
+    ｬ: "ャ",
+    ｭ: "ュ",
+    ｮ: "ョ",
+    ｯ: "ッ",
+  };
+
+  // 半角カナを全角カナに変換
+  let result = text.replace(/[ｱ-ﾝ]/g, (match) => hankakuMap[match] || match);
+
+  // 半角の濁点・半濁点を全角に変換（゛゜）
+  result = result.replace(/ｶﾞ/g, "ガ");
+  result = result.replace(/ｷﾞ/g, "ギ");
+  result = result.replace(/ｸﾞ/g, "グ");
+  result = result.replace(/ｹﾞ/g, "ゲ");
+  result = result.replace(/ｺﾞ/g, "ゴ");
+  result = result.replace(/ｻﾞ/g, "ザ");
+  result = result.replace(/ｼﾞ/g, "ジ");
+  result = result.replace(/ｽﾞ/g, "ズ");
+  result = result.replace(/ｾﾞ/g, "ゼ");
+  result = result.replace(/ｿﾞ/g, "ゾ");
+  result = result.replace(/ﾀﾞ/g, "ダ");
+  result = result.replace(/ﾁﾞ/g, "ヂ");
+  result = result.replace(/ﾂﾞ/g, "ヅ");
+  result = result.replace(/ﾃﾞ/g, "デ");
+  result = result.replace(/ﾄﾞ/g, "ド");
+  result = result.replace(/ﾊﾞ/g, "バ");
+  result = result.replace(/ﾋﾞ/g, "ビ");
+  result = result.replace(/ﾌﾞ/g, "ブ");
+  result = result.replace(/ﾍﾞ/g, "ベ");
+  result = result.replace(/ﾎﾞ/g, "ボ");
+  result = result.replace(/ﾊﾟ/g, "パ");
+  result = result.replace(/ﾋﾟ/g, "ピ");
+  result = result.replace(/ﾌﾟ/g, "プ");
+  result = result.replace(/ﾍﾟ/g, "ペ");
+  result = result.replace(/ﾎﾟ/g, "ポ");
+
+  return result;
+}
+
+/**
  * マッピングを適用してトランザクションデータを抽出
  * @param {Array<string>} values - CSV行のデータ配列
  * @param {Object} columns - 列マッピング
@@ -138,10 +240,10 @@ function extractTransactionData(values, columns) {
   return {
     transactionDate,
     amount: parseFloat(amount.replace(/[^0-9.-]/g, "")), // 数字のみ抽出
-    category: values[columns["区分"]]?.trim() || "",
+    category: convertHankakuToZenkaku(values[columns["区分"]]?.trim() || ""),
     balance: parseFloat(balance.replace(/[^0-9.-]/g, "")),
-    description,
-    comments: values[columns["コメント"]]?.trim() || "",
+    description: convertHankakuToZenkaku(description),
+    comments: convertHankakuToZenkaku(values[columns["コメント"]]?.trim() || ""),
     categoryAuto: "", // 将来的に自動化
   };
 }

--- a/src/bankCsvParser.js
+++ b/src/bankCsvParser.js
@@ -1,0 +1,135 @@
+const { downloadFile } = require("./bankDriveHelper");
+
+const MAPPING_FILENAME = "bank_mapping.json";
+
+/**
+ * フォルダからマッピング設定をダウンロード
+ * @param {string} bankFolderId - 銀行フォルダID
+ * @returns {Promise<Object>} マッピング設定
+ */
+async function loadBankMapping(bankFolderId) {
+  try {
+    // フォルダ内のファイル一覧を取得
+    const { google } = require("googleapis");
+    const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON);
+    const auth = new google.auth.GoogleAuth({
+      credentials,
+      scopes: ["https://www.googleapis.com/auth/drive"],
+    });
+    const drive = google.drive({ version: "v3", auth });
+
+    const response = await drive.files.list({
+      q: `'${bankFolderId}' in parents and name='${MAPPING_FILENAME}' and trashed=false`,
+      spaces: "drive",
+      fields: "files(id)",
+      pageSize: 1,
+    });
+
+    if (!response.data.files || response.data.files.length === 0) {
+      throw new Error(`${MAPPING_FILENAME} が見つかりません`);
+    }
+
+    const mappingFileId = response.data.files[0].id;
+    const buffer = await downloadFile(mappingFileId);
+    const mapping = JSON.parse(buffer.toString("utf-8"));
+
+    return mapping;
+  } catch (err) {
+    throw new Error(`マッピング設定の読み込みエラー: ${err.message}`);
+  }
+}
+
+/**
+ * CSVをパースしてオブジェクト配列に変換
+ * @param {Buffer} csvBuffer - CSVファイルの内容
+ * @param {Object} mapping - マッピング設定 { columns: { "取引日": 0, "金額": 1, ... } }
+ * @returns {Array<Object>} パース済みのトランザクションリスト
+ */
+function parseCSV(csvBuffer, mapping) {
+  const csv = csvBuffer.toString("utf-8");
+  const lines = csv.split("\n").filter((line) => line.trim());
+
+  if (lines.length === 0) {
+    return [];
+  }
+
+  const transactions = [];
+
+  // 最初の行をヘッダーとして処理するか、列インデックスで処理するか
+  // マッピングで列インデックスが指定されているため、全行がデータ
+  const startIndex = mapping.skipHeaderRow ? 1 : 0;
+
+  for (let i = startIndex; i < lines.length; i++) {
+    const values = parseCSVLine(lines[i]);
+    const transaction = extractTransactionData(values, mapping.columns);
+
+    if (transaction) {
+      transactions.push(transaction);
+    }
+  }
+
+  return transactions;
+}
+
+/**
+ * CSVの1行をパース（シンプルな実装、クォート対応）
+ */
+function parseCSVLine(line) {
+  const result = [];
+  let current = "";
+  let insideQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === '"') {
+      if (insideQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++; // スキップ
+      } else {
+        insideQuotes = !insideQuotes;
+      }
+    } else if (char === "," && !insideQuotes) {
+      result.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current.trim());
+  return result;
+}
+
+/**
+ * マッピングを適用してトランザクションデータを抽出
+ * @param {Array<string>} values - CSV行のデータ配列
+ * @param {Object} columns - 列マッピング
+ * @returns {Object|null} トランザクションオブジェクト
+ */
+function extractTransactionData(values, columns) {
+  // 必須フィールド
+  const transactionDate = values[columns["取引日"]]?.trim();
+  const amount = values[columns["金額"]]?.trim();
+  const description = values[columns["摘要"]]?.trim();
+  const balance = values[columns["残高"]]?.trim();
+
+  if (!transactionDate || !amount || !description || !balance) {
+    return null; // 必須データが不足している行はスキップ
+  }
+
+  return {
+    transactionDate,
+    amount: parseFloat(amount.replace(/[^0-9.-]/g, "")), // 数字のみ抽出
+    category: values[columns["区分"]]?.trim() || "",
+    balance: parseFloat(balance.replace(/[^0-9.-]/g, "")),
+    description,
+    comments: values[columns["コメント"]]?.trim() || "",
+    categoryAuto: "", // 将来的に自動化
+  };
+}
+
+module.exports = {
+  loadBankMapping,
+  parseCSV,
+};

--- a/src/bankDriveHelper.js
+++ b/src/bankDriveHelper.js
@@ -1,0 +1,90 @@
+const { google } = require("googleapis");
+const { Readable } = require("stream");
+
+const SCOPES = ["https://www.googleapis.com/auth/drive"];
+
+function getAuth() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON);
+  return new google.auth.GoogleAuth({
+    credentials,
+    scopes: SCOPES,
+  });
+}
+
+/**
+ * 指定フォルダ内のCSVファイル一覧を取得
+ * @param {string} folderId - Google Drive フォルダID
+ * @returns {Promise<Array>} CSVファイルのリスト
+ */
+async function listCsvFiles(folderId) {
+  const auth = getAuth();
+  const drive = google.drive({ version: "v3", auth });
+
+  const response = await drive.files.list({
+    q: `'${folderId}' in parents and mimeType='text/csv' and trashed=false`,
+    spaces: "drive",
+    fields: "files(id, name, createdTime, modifiedTime)",
+    pageSize: 100,
+  });
+
+  return response.data.files || [];
+}
+
+/**
+ * ファイルの内容をバッファとして取得
+ * @param {string} fileId - Google Drive ファイルID
+ * @returns {Promise<Buffer>} ファイルの内容
+ */
+async function downloadFile(fileId) {
+  const auth = getAuth();
+  const drive = google.drive({ version: "v3", auth });
+
+  const response = await drive.files.get(
+    { fileId, alt: "media" },
+    { responseType: "stream" }
+  );
+
+  return streamToBuffer(response.data);
+}
+
+/**
+ * ファイルをフォルダに移動
+ * @param {string} fileId - Google Drive ファイルID
+ * @param {string} targetFolderId - 移動先フォルダID
+ */
+async function moveFile(fileId, targetFolderId) {
+  const auth = getAuth();
+  const drive = google.drive({ version: "v3", auth });
+
+  const file = await drive.files.get({
+    fileId,
+    fields: "parents",
+  });
+
+  const previousParents = file.data.parents;
+
+  await drive.files.update({
+    fileId,
+    addParents: targetFolderId,
+    removeParents: previousParents.join(","),
+    fields: "id, parents",
+  });
+}
+
+/**
+ * ReadableStream を Buffer に変換する
+ */
+function streamToBuffer(stream) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    stream.on("data", (chunk) => chunks.push(chunk));
+    stream.on("end", () => resolve(Buffer.concat(chunks)));
+    stream.on("error", reject);
+  });
+}
+
+module.exports = {
+  listCsvFiles,
+  downloadFile,
+  moveFile,
+};

--- a/src/bankTransactionDedup.js
+++ b/src/bankTransactionDedup.js
@@ -31,8 +31,8 @@ async function getExistingTransactions(spreadsheetId, sheetName) {
     const transactions = rows.slice(1).map((row) => ({
       transactionDate: row[0] || "",
       amount: parseFloat(row[1]) || 0,
-      description: row[3] || "", // 摘要
-      balance: parseFloat(row[4]) || 0,
+      balance: parseFloat(row[3]) || 0, // D列: 残高
+      description: row[4] || "",        // E列: 摘要
     }));
 
     return transactions;

--- a/src/bankTransactionDedup.js
+++ b/src/bankTransactionDedup.js
@@ -1,0 +1,86 @@
+const { google } = require("googleapis");
+
+const SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
+
+function getAuth() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON);
+  return new google.auth.GoogleAuth({
+    credentials,
+    scopes: SCOPES,
+  });
+}
+
+/**
+ * スプレッドシートから既存のトランザクション一覧を取得
+ * @param {string} spreadsheetId - スプレッドシートID
+ * @param {string} sheetName - シート名
+ * @returns {Promise<Array>} 既存トランザクションのリスト
+ */
+async function getExistingTransactions(spreadsheetId, sheetName) {
+  const auth = getAuth();
+  const sheets = google.sheets({ version: "v4", auth });
+
+  try {
+    const response = await sheets.spreadsheets.values.get({
+      spreadsheetId,
+      range: `${sheetName}!A:E`, // 取引日、金額、摘要、残高を取得
+    });
+
+    const rows = response.data.values || [];
+    // 最初の行はヘッダー、スキップ
+    const transactions = rows.slice(1).map((row) => ({
+      transactionDate: row[0] || "",
+      amount: parseFloat(row[1]) || 0,
+      description: row[3] || "", // 摘要
+      balance: parseFloat(row[4]) || 0,
+    }));
+
+    return transactions;
+  } catch (err) {
+    console.error("既存トランザクション取得エラー:", err);
+    return [];
+  }
+}
+
+/**
+ * 新しいトランザクションが既に存在するかチェック
+ * @param {Object} newTransaction - 新しいトランザクション
+ * @param {Array<Object>} existingTransactions - 既存トランザクション
+ * @returns {boolean} 重複しているかどうか
+ */
+function isDuplicate(newTransaction, existingTransactions) {
+  return existingTransactions.some(
+    (existing) =>
+      existing.transactionDate === newTransaction.transactionDate &&
+      existing.amount === newTransaction.amount &&
+      existing.description === newTransaction.description &&
+      existing.balance === newTransaction.balance
+  );
+}
+
+/**
+ * トランザクションリストから重複を除外
+ * @param {Array<Object>} newTransactions - 新しいトランザクションリスト
+ * @param {Array<Object>} existingTransactions - 既存トランザクション
+ * @returns {Object} { unique, duplicate } の配列
+ */
+function filterDuplicates(newTransactions, existingTransactions) {
+  const unique = [];
+  const duplicate = [];
+
+  newTransactions.forEach((transaction) => {
+    if (isDuplicate(transaction, existingTransactions)) {
+      duplicate.push(transaction);
+    } else {
+      unique.push(transaction);
+    }
+  });
+
+  return { unique, duplicate };
+}
+
+module.exports = {
+  getExistingTransactions,
+  isDuplicate,
+  filterDuplicates,
+};

--- a/src/bankTransactionImporter.js
+++ b/src/bankTransactionImporter.js
@@ -1,0 +1,240 @@
+const { google } = require("googleapis");
+const { listCsvFiles, downloadFile, moveFile } = require("./bankDriveHelper");
+const { loadBankMapping, parseCSV } = require("./bankCsvParser");
+const {
+  getExistingTransactions,
+  filterDuplicates,
+} = require("./bankTransactionDedup");
+const { logImportResult } = require("./bankTransactionLogger");
+
+const SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
+
+function getAuth() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON);
+  return new google.auth.GoogleAuth({
+    credentials,
+    scopes: SCOPES,
+  });
+}
+
+/**
+ * サブフォルダを取得または作成
+ */
+async function getOrCreateSubfolder(auth, parentFolderId, folderName) {
+  const drive = google.drive({ version: "v3", auth: auth });
+
+  // 既存フォルダを確認
+  const response = await drive.files.list({
+    q: `'${parentFolderId}' in parents and name='${folderName}' and mimeType='application/vnd.google-apps.folder' and trashed=false`,
+    spaces: "drive",
+    fields: "files(id)",
+    pageSize: 1,
+  });
+
+  if (response.data.files && response.data.files.length > 0) {
+    return response.data.files[0].id;
+  }
+
+  // フォルダを作成
+  const createResponse = await drive.files.create({
+    requestBody: {
+      name: folderName,
+      mimeType: "application/vnd.google-apps.folder",
+      parents: [parentFolderId],
+    },
+    fields: "id",
+  });
+
+  return createResponse.data.id;
+}
+
+/**
+ * 銀行取引CSVをスプレッドシートにインポート
+ * @param {string} spreadsheetId - スプレッドシートID
+ * @param {string} bankFolderId - 銀行フォルダID
+ * @returns {Promise<Object>} インポート結果
+ */
+async function importBankTransactions(spreadsheetId, bankFolderId) {
+  const timestamp = new Date().toLocaleString("ja-JP", {
+    timeZone: "Asia/Tokyo",
+  });
+  const results = [];
+
+  try {
+    // マッピング設定を読み込む
+    const mapping = await loadBankMapping(bankFolderId);
+
+    // CSVファイル一覧を取得
+    const csvFiles = await listCsvFiles(bankFolderId);
+
+    if (csvFiles.length === 0) {
+      return {
+        status: "success",
+        message: "処理対象のCSVファイルがありません",
+        timestamp,
+        results: [],
+      };
+    }
+
+    // 既存トランザクションを取得
+    const bankTransSheetName = process.env.BANK_TRANS_SHEET_NAME || "bank trans";
+    const existingTransactions = await getExistingTransactions(
+      spreadsheetId,
+      bankTransSheetName
+    );
+
+    // サブフォルダを取得・作成
+    const auth = new google.auth.GoogleAuth({
+      credentials: JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON),
+      scopes: ["https://www.googleapis.com/auth/drive"],
+    });
+    const successFolderId = await getOrCreateSubfolder(
+      auth,
+      bankFolderId,
+      "処理済み"
+    );
+    const failureFolderId = await getOrCreateSubfolder(
+      auth,
+      bankFolderId,
+      "要確認"
+    );
+
+    // 各CSVファイルを処理
+    for (const file of csvFiles) {
+      const fileResult = await processSingleFile(
+        file,
+        spreadsheetId,
+        mapping,
+        existingTransactions,
+        successFolderId,
+        failureFolderId,
+        timestamp
+      );
+      results.push(fileResult);
+    }
+
+    const successCount = results.filter((r) => r.status === "success").length;
+    const failureCount = results.filter((r) => r.status === "failure").length;
+
+    return {
+      status: "completed",
+      message: `${successCount}ファイル成功、${failureCount}ファイル失敗`,
+      timestamp,
+      results,
+    };
+  } catch (err) {
+    console.error("インポート処理エラー:", err);
+    return {
+      status: "error",
+      message: err.message,
+      timestamp,
+      results,
+    };
+  }
+}
+
+/**
+ * 単一のCSVファイルを処理
+ */
+async function processSingleFile(
+  file,
+  spreadsheetId,
+  mapping,
+  existingTransactions,
+  successFolderId,
+  failureFolderId,
+  timestamp
+) {
+  const fileResult = {
+    fileName: file.name,
+    status: "failure",
+    totalRows: 0,
+    importedRows: 0,
+    duplicateRows: 0,
+    errorMessage: "",
+  };
+
+  try {
+    // ファイルをダウンロード
+    const csvBuffer = await downloadFile(file.id);
+
+    // CSVをパース
+    const transactions = parseCSV(csvBuffer, mapping);
+    fileResult.totalRows = transactions.length;
+
+    // 重複をチェック
+    const { unique, duplicate } = filterDuplicates(
+      transactions,
+      existingTransactions
+    );
+    fileResult.duplicateRows = duplicate.length;
+
+    // 新規トランザクションをスプレッドシートに追記
+    if (unique.length > 0) {
+      await appendTransactionsToSheet(spreadsheetId, unique);
+      fileResult.importedRows = unique.length;
+
+      // 既存トランザクションに新規を追加（次ファイル処理時の重複チェック用）
+      existingTransactions.push(...unique);
+    }
+
+    // ファイルを「処理済み」フォルダに移動
+    await moveFile(file.id, successFolderId);
+    fileResult.status = "success";
+
+    // ログを記録
+    await logImportResult(spreadsheetId, {
+      timestamp,
+      ...fileResult,
+    });
+  } catch (err) {
+    console.error(`ファイル処理エラー (${file.name}):`, err);
+    fileResult.errorMessage = err.message;
+
+    try {
+      // 失敗したファイルを「要確認」フォルダに移動
+      await moveFile(file.id, failureFolderId);
+
+      // ログを記録
+      await logImportResult(spreadsheetId, {
+        timestamp,
+        ...fileResult,
+      });
+    } catch (moveErr) {
+      console.error(`ファイル移動エラー (${file.name}):`, moveErr);
+    }
+  }
+
+  return fileResult;
+}
+
+/**
+ * トランザクションをスプレッドシートに追記
+ */
+async function appendTransactionsToSheet(spreadsheetId, transactions) {
+  const auth = getAuth();
+  const sheets = google.sheets({ version: "v4", auth });
+  const sheetName = process.env.BANK_TRANS_SHEET_NAME || "bank trans";
+
+  const values = transactions.map((t) => [
+    t.transactionDate,
+    t.amount,
+    t.category,
+    t.balance,
+    t.description,
+    t.comments,
+    t.categoryAuto,
+  ]);
+
+  await sheets.spreadsheets.values.append({
+    spreadsheetId,
+    range: `${sheetName}!A:G`,
+    valueInputOption: "USER_ENTERED",
+    insertDataOption: "INSERT_ROWS",
+    requestBody: { values },
+  });
+}
+
+module.exports = {
+  importBankTransactions,
+};

--- a/src/bankTransactionImporter.js
+++ b/src/bankTransactionImporter.js
@@ -63,6 +63,7 @@ async function importBankTransactions(spreadsheetId, bankFolderId) {
   try {
     // マッピング設定を読み込む
     const mapping = await loadBankMapping(bankFolderId);
+    const bankName = mapping.bankName || "不明";
 
     // CSVファイル一覧を取得
     const csvFiles = await listCsvFiles(bankFolderId);
@@ -105,6 +106,7 @@ async function importBankTransactions(spreadsheetId, bankFolderId) {
         file,
         spreadsheetId,
         mapping,
+        bankName,
         existingTransactions,
         successFolderId,
         failureFolderId,
@@ -140,6 +142,7 @@ async function processSingleFile(
   file,
   spreadsheetId,
   mapping,
+  bankName,
   existingTransactions,
   successFolderId,
   failureFolderId,
@@ -171,7 +174,7 @@ async function processSingleFile(
 
     // 新規トランザクションをスプレッドシートに追記
     if (unique.length > 0) {
-      await appendTransactionsToSheet(spreadsheetId, unique);
+      await appendTransactionsToSheet(spreadsheetId, bankName, unique);
       fileResult.importedRows = unique.length;
 
       // 既存トランザクションに新規を追加（次ファイル処理時の重複チェック用）
@@ -184,6 +187,8 @@ async function processSingleFile(
 
     // ログを記録
     await logResult(spreadsheetId, {
+      processName: "bank trans",
+      bankName,
       timestamp,
       ...fileResult,
     });
@@ -196,7 +201,9 @@ async function processSingleFile(
       await moveFile(file.id, failureFolderId);
 
       // ログを記録
-      await logImportResult(spreadsheetId, {
+      await logResult(spreadsheetId, {
+        processName: "bank trans",
+        bankName,
         timestamp,
         ...fileResult,
       });
@@ -211,7 +218,7 @@ async function processSingleFile(
 /**
  * トランザクションをスプレッドシートに追記
  */
-async function appendTransactionsToSheet(spreadsheetId, transactions) {
+async function appendTransactionsToSheet(spreadsheetId, bankName, transactions) {
   const auth = getAuth();
   const sheets = google.sheets({ version: "v4", auth });
   const sheetName = process.env.BANK_TRANS_SHEET_NAME || "bank trans";
@@ -224,11 +231,12 @@ async function appendTransactionsToSheet(spreadsheetId, transactions) {
     t.description,
     t.comments,
     t.categoryAuto,
+    bankName,
   ]);
 
   await sheets.spreadsheets.values.append({
     spreadsheetId,
-    range: `${sheetName}!A:G`,
+    range: `${sheetName}!A:H`,
     valueInputOption: "USER_ENTERED",
     insertDataOption: "INSERT_ROWS",
     requestBody: { values },

--- a/src/bankTransactionImporter.js
+++ b/src/bankTransactionImporter.js
@@ -5,7 +5,7 @@ const {
   getExistingTransactions,
   filterDuplicates,
 } = require("./bankTransactionDedup");
-const { logImportResult } = require("./bankTransactionLogger");
+const { logResult } = require("./logger");
 
 const SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
 
@@ -183,7 +183,7 @@ async function processSingleFile(
     fileResult.status = "success";
 
     // ログを記録
-    await logImportResult(spreadsheetId, {
+    await logResult(spreadsheetId, {
       timestamp,
       ...fileResult,
     });

--- a/src/bankTransactionLogger.js
+++ b/src/bankTransactionLogger.js
@@ -1,0 +1,62 @@
+const { google } = require("googleapis");
+
+const SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
+
+function getAuth() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON);
+  return new google.auth.GoogleAuth({
+    credentials,
+    scopes: SCOPES,
+  });
+}
+
+/**
+ * インポート処理ログをスプレッドシートに記録
+ * @param {string} spreadsheetId - スプレッドシートID
+ * @param {Object} logEntry - ログエントリ
+ */
+async function logImportResult(
+  spreadsheetId,
+  {
+    timestamp,
+    fileName,
+    status, // "success" | "failure"
+    totalRows,
+    importedRows,
+    duplicateRows,
+    errorMessage = "",
+  }
+) {
+  const auth = getAuth();
+  const sheets = google.sheets({ version: "v4", auth });
+  const logsSheetName = process.env.BANK_LOGS_SHEET_NAME || "logs";
+
+  const values = [
+    [
+      timestamp,
+      fileName,
+      status,
+      totalRows,
+      importedRows,
+      duplicateRows,
+      errorMessage,
+    ],
+  ];
+
+  try {
+    await sheets.spreadsheets.values.append({
+      spreadsheetId,
+      range: `${logsSheetName}!A:G`,
+      valueInputOption: "USER_ENTERED",
+      insertDataOption: "INSERT_ROWS",
+      requestBody: { values },
+    });
+  } catch (err) {
+    console.error("ログ記録エラー:", err);
+    throw err;
+  }
+}
+
+module.exports = {
+  logImportResult,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ require('dotenv').config({ path: process.env.DOTENV_PATH || '.env.local' });
 const express = require("express");
 const { middleware, Client } = require("@line/bot-sdk");
 const { handleEvent } = require("./lineHandler");
+const { importBankTransactions } = require("./bankTransactionImporter");
 
 const config = {
   channelSecret: process.env.LINE_CHANNEL_SECRET,
@@ -10,6 +11,9 @@ const config = {
 };
 
 const app = express();
+
+// ボディパーサーの設定
+app.use(express.json());
 
 app.post("/webhook", middleware(config), (req, res) => {
   // すぐにレスポンスを返す（LINE のタイムアウト防止）
@@ -21,6 +25,39 @@ app.post("/webhook", middleware(config), (req, res) => {
       console.error("イベント処理エラー:", err);
     });
   });
+});
+
+/**
+ * 銀行取引CSVのインポート
+ * POST /bank/import
+ * リクエストボディ: { spreadsheetId: "...", bankFolderId: "..." }
+ */
+app.post("/bank/import", async (req, res) => {
+  try {
+    const spreadsheetId = req.body.spreadsheetId || process.env.SPREADSHEET_ID;
+    const bankFolderId = req.body.bankFolderId || process.env.BANK_FOLDER_ID;
+
+    if (!spreadsheetId || !bankFolderId) {
+      return res.status(400).json({
+        status: "error",
+        message: "spreadsheetId または bankFolderId が指定されていません",
+      });
+    }
+
+    console.log(
+      `銀行取引インポート開始: spreadsheetId=${spreadsheetId}, bankFolderId=${bankFolderId}`
+    );
+
+    const result = await importBankTransactions(spreadsheetId, bankFolderId);
+
+    res.status(200).json(result);
+  } catch (err) {
+    console.error("/bank/import エラー:", err);
+    res.status(500).json({
+      status: "error",
+      message: err.message,
+    });
+  }
 });
 
 app.get("/health", (_req, res) => res.send("OK"));

--- a/src/logger.js
+++ b/src/logger.js
@@ -11,11 +11,11 @@ function getAuth() {
 }
 
 /**
- * インポート処理ログをスプレッドシートに記録
+ * ログをスプレッドシートに記録
  * @param {string} spreadsheetId - スプレッドシートID
  * @param {Object} logEntry - ログエントリ
  */
-async function logImportResult(
+async function logResult(
   spreadsheetId,
   {
     timestamp,
@@ -29,7 +29,7 @@ async function logImportResult(
 ) {
   const auth = getAuth();
   const sheets = google.sheets({ version: "v4", auth });
-  const logsSheetName = process.env.BANK_LOGS_SHEET_NAME || "logs";
+  const logsSheetName = process.env.LOGS_SHEET_NAME || "logs";
 
   const values = [
     [
@@ -58,5 +58,5 @@ async function logImportResult(
 }
 
 module.exports = {
-  logImportResult,
+  logResult,
 };

--- a/src/logger.js
+++ b/src/logger.js
@@ -18,6 +18,8 @@ function getAuth() {
 async function logResult(
   spreadsheetId,
   {
+    processName = "",
+    bankName = "",
     timestamp,
     fileName,
     status, // "success" | "failure"
@@ -34,6 +36,8 @@ async function logResult(
   const values = [
     [
       timestamp,
+      processName,
+      bankName,
       fileName,
       status,
       totalRows,
@@ -46,7 +50,7 @@ async function logResult(
   try {
     await sheets.spreadsheets.values.append({
       spreadsheetId,
-      range: `${logsSheetName}!A:G`,
+      range: `${logsSheetName}!A:I`,
       valueInputOption: "USER_ENTERED",
       insertDataOption: "INSERT_ROWS",
       requestBody: { values },


### PR DESCRIPTION
## 概要

Google Drive に置いた銀行取引 CSV をスプレッドシートにインポートする機能を追加。

## 主な機能

- **POST /bank/import** エンドポイントで CSV インポートを実行
- **Shift-JIS 対応**・半角カナ全角変換・NFC 正規化
- **銀行ごとのマッピング設定**（`bank_mapping.json`）で列構成を柔軟に定義
- **重複チェック**（取引日・金額・摘要・残高で照合）
- 処理済みファイルを「処理済み」フォルダへ、失敗ファイルを「要確認」フォルダへ自動移動
- 処理結果を logs シートに記録

## スプレッドシートの変更

### bank trans シート（新規 H 列）

| H |
|---|
| 銀行名（マッピングファイルの `bankName` から取得）|

### logs シート（B・C 列を追加、A:G → A:I）

| B | C |
|---|---|
| 処理名（`bank trans` 固定）| 銀行名 |

## 新規ファイル

| ファイル | 説明 |
|---------|------|
| `src/bankTransactionImporter.js` | インポート処理のオーケストレーション |
| `src/bankCsvParser.js` | CSV パース・文字コード変換 |
| `src/bankTransactionDedup.js` | 重複チェック |
| `src/bankDriveHelper.js` | Drive からの取得・移動 |
| `src/logger.js` | logs シートへの記録 |
| `conf/bank_mapping/saitamaresona.json` | 埼玉りそな銀行用マッピングサンプル |

## スプレッドシートのヘッダー更新が必要

**bank trans シート:** H 列に `銀行名` を追加
**logs シート:** 列を `タイムスタンプ / 処理名 / 銀行名 / ファイル名 / ステータス / 総行数 / インポート行数 / 重複行数 / エラーメッセージ` に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)