### PR TITLE
feat: カード利用明細CSVインポート機能の追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"..."}
 # 銀行取引インポート
 BANK_FOLDER_ID=your_bank_folder_id
 BANK_TRANS_SHEET_NAME=bank trans
+
+# カード取引インポート
+CARD_FOLDER_ID=your_card_folder_id
+CARD_TRANS_SHEET_NAME=card trans

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ LINE グループ内で共有されたレシート画像を自動で解析し、
 - **自動解析** — Gemini API でレシート情報（店名・金額・支払い日時・支払い方法・品目）を構造化データに変換
 - **スプレッドシート統合** — リアルタイムでレシート情報を集計できる
 - **銀行取引インポート** — Shift-JIS の CSV に対応、銀行ごとのマッピング設定で複数口座を管理
+- **カード利用明細インポート** — 楽天カード等の CSV に対応、カードごとのマッピング設定で複数カードを管理
 
 ## 使い方
 
@@ -42,6 +43,18 @@ curl -X POST https://{cloud-run-url}/bank/import
 - 失敗ファイルは「要確認」フォルダへ移動
 - 処理結果は logs シートに記録
 
+### ③ カード利用明細のインポート
+
+銀行取引と同様に、Google Drive のフォルダに CSV を置いて POST リクエストを送ります。
+
+```bash
+curl -X POST https://{cloud-run-url}/card/import
+```
+
+- ファイル内の重複はすべて取り込み、スプレッドシート既存データと一致する場合のみスキップ
+- 重複キー: 利用日 + 利用店名 + 利用者 + 利用金額
+- 処理結果は logs シートに記録（処理名: `card trans`）
+
 ## システム構成
 
 ```
@@ -63,19 +76,24 @@ LINE Bot
 
 ```
 src/
-├── index.js                 # Express サーバー + Webhook / bank/import エンドポイント
-├── lineHandler.js           # LINE イベント処理（画像受信・ユーザー取得）
-├── geminiParser.js          # Gemini でレシート画像を構造化データに変換
-├── sheetsLogger.js          # receipts シートに記録
-├── bankTransactionImporter.js  # 銀行取引インポート処理のオーケストレーション
-├── bankCsvParser.js         # CSV パース（Shift-JIS 対応・半角カナ全角変換）
-├── bankTransactionDedup.js  # 重複チェック
-├── bankDriveHelper.js       # Google Drive からの CSV 取得・移動
-└── logger.js                # logs シートへの処理結果記録
+├── index.js                   # Express サーバー + Webhook / bank/import / card/import エンドポイント
+├── lineHandler.js             # LINE イベント処理（画像受信・ユーザー取得）
+├── geminiParser.js            # Gemini でレシート画像を構造化データに変換
+├── sheetsLogger.js            # receipts シートに記録
+├── bankTransactionImporter.js # 銀行取引インポート処理のオーケストレーション
+├── bankCsvParser.js           # 銀行 CSV パース（Shift-JIS 対応・半角カナ全角変換）
+├── bankTransactionDedup.js    # 銀行取引の重複チェック
+├── bankDriveHelper.js         # Google Drive からの CSV 取得・移動（bank/card 共用）
+├── cardTransactionImporter.js # カード取引インポート処理のオーケストレーション
+├── cardCsvParser.js           # カード CSV パース・card_mapping.json 読み込み
+├── cardTransactionDedup.js    # カード取引の重複チェック
+└── logger.js                  # logs シートへの処理結果記録
 
 conf/
-└── bank_mapping/            # 銀行ごとのマッピング設定
-    └── saitamaresona.json   # 埼玉りそな銀行用サンプル
+├── bank_mapping/              # 銀行ごとのマッピング設定
+│   └── saitamaresona.json     # 埼玉りそな銀行用サンプル
+└── card_mapping/              # カードごとのマッピング設定
+    └── rakuten.json           # 楽天カード用サンプル
 
 docs/
 ├── SETUP.md         # セットアップ手順
@@ -123,6 +141,20 @@ Dockerfile           # Cloud Run デプロイ用
 | H | 支払い方法 |
 | I | 品目 |
 | J | 備考 |
+
+### card trans シート（カード利用明細）
+
+| 列 | 項目 |
+|----|------|
+| A | 利用日 |
+| B | 利用店名・商品名 |
+| C | 利用者 |
+| D | 支払方法 |
+| E | 利用金額 |
+| F | 手数料/利息 |
+| G | 支払総額 |
+| H | 支払月 |
+| I | カード名 |
 
 ### bank trans シート（銀行取引）
 

--- a/conf/card_mapping/rakuten.json
+++ b/conf/card_mapping/rakuten.json
@@ -1,0 +1,16 @@
+{
+  "cardName": "楽天カード",
+  "encoding": "utf-8",
+  "skipHeaderRow": true,
+  "skipFooterRow": false,
+  "columns": {
+    "利用日": 0,
+    "利用店名": 1,
+    "利用者": 2,
+    "支払方法": 3,
+    "利用金額": 4,
+    "手数料/利息": 5,
+    "支払総額": 6,
+    "支払月": 7
+  }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -6,6 +6,7 @@
 |---------|------|------|
 | POST | `/webhook` | LINE Messaging API からのイベント受信 |
 | POST | `/bank/import` | 銀行取引 CSV インポート |
+| POST | `/card/import` | カード利用明細 CSV インポート |
 | GET | `/health` | ヘルスチェック |
 
 ---
@@ -54,6 +55,86 @@ X-Line-Signature: {署名}
 
 1. LINE Webhook を受け取り即座に 200 を返す（タイムアウト防止）
 2. バックグラウンドで画像解析・Sheets 記録・返信を実行
+
+---
+
+## POST /card/import
+
+カード利用明細 CSV をスプレッドシートにインポートします。
+
+**リクエスト:**
+
+```
+POST https://{cloud-run-url}/card/import
+Content-Type: application/json
+```
+
+**リクエストボディ（省略可）:**
+
+```json
+{
+  "spreadsheetId": "1V3GW_...",
+  "cardFolderId": "1abc..."
+}
+```
+
+省略した場合は環境変数 `SPREADSHEET_ID` / `CARD_FOLDER_ID` を使用。
+
+**レスポンス（成功）:**
+
+```json
+{
+  "status": "completed",
+  "message": "1ファイル成功、0ファイル失敗",
+  "timestamp": "2026/04/28 10:00:00",
+  "results": [
+    {
+      "fileName": "enavi202605.csv",
+      "status": "success",
+      "totalRows": 30,
+      "importedRows": 28,
+      "duplicateRows": 2,
+      "errorMessage": ""
+    }
+  ]
+}
+```
+
+**重複チェックの仕様:**
+- ファイル内の重複行はすべて取り込む
+- スプレッドシートの既存データと一致する場合のみスキップ
+- 照合キー: 利用日 + 利用店名 + 利用者 + 利用金額
+
+**フォルダ構成:**
+
+```
+{CARD_FOLDER_ID}/
+├── card_mapping.json   # マッピング設定（必須）
+├── enavi202605.csv     # インポート対象 CSV
+├── 処理済み/           # 成功ファイルの移動先（自動作成）
+└── 要確認/             # 失敗ファイルの移動先（自動作成）
+```
+
+**card_mapping.json の形式:**
+
+```json
+{
+  "cardName": "楽天カード",
+  "encoding": "utf-8",
+  "skipHeaderRow": true,
+  "skipFooterRow": false,
+  "columns": {
+    "利用日": 0,
+    "利用店名": 1,
+    "利用者": 2,
+    "支払方法": 3,
+    "利用金額": 4,
+    "手数料/利息": 5,
+    "支払総額": 6,
+    "支払月": 7
+  }
+}
+```
 
 ---
 
@@ -241,6 +322,22 @@ Content-Type: application/json
 | G | String | カテゴリ（自動）| `` |
 | H | String | 銀行名 | `共通口座（埼玉りそな）` |
 
+### card trans シート（カード利用明細）
+
+追記範囲: `{CARD_TRANS_SHEET_NAME}!A:I`
+
+| 列 | タイプ | 項目 | 例 |
+|----|--------|------|----|
+| A | String | 利用日 | `2026/04/24` |
+| B | String | 利用店名・商品名 | `ビーンズムサシウラワ` |
+| C | String | 利用者 | `本人` |
+| D | String | 支払方法 | `1回払い` |
+| E | Number | 利用金額 | `3002` |
+| F | Number | 手数料/利息 | `0` |
+| G | Number | 支払総額 | `3002` |
+| H | String | 支払月 | `5月` |
+| I | String | カード名 | `楽天カード` |
+
 ### logs シート（インポート処理ログ）
 
 追記範囲: `{LOGS_SHEET_NAME}!A:I`
@@ -309,6 +406,12 @@ Content-Type: application/json
 
 - Free tier の RPD（20件/日）を超過している可能性
 - AI Studio の Rate Limit ページで使用量を確認: https://aistudio.google.com/app/rate-limit
+
+### card/import でファイルが見つからない
+
+- `card_mapping.json` がフォルダ直下に配置されているか確認
+- サービスアカウントに Drive の閲覧・編集権限があるか確認
+- `CARD_FOLDER_ID` が正しいか確認
 
 ### bank/import でファイルが見つからない
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,36 +20,38 @@
         │ (receipt-log-bot)                   │
         │                                      │
         │  ┌─────────────────────────────┐   │
-        │  │  Express Server (Port 8080) │   │
-        │  │  - /webhook    (POST)       │   │
-        │  │  - /bank/import (POST)      │   │
-        │  │  - /health     (GET)        │   │
-        │  └────────┬──────────┬─────────┘   │
+        │  │  Express Server (Port 8080)  │   │
+        │  │  - /webhook      (POST)      │   │
+        │  │  - /bank/import  (POST)      │   │
+        │  │  - /card/import  (POST)      │   │
+        │  │  - /health       (GET)       │   │
+        │  └────────┬──────────┬──────────┘   │
         │           │          │              │
-        │  ┌────────▼──────┐  ┌▼──────────────────────────┐  │
-        │  │ lineHandler   │  │ bankTransactionImporter    │  │
-        │  ├───────────────┤  ├────────────────────────────┤  │
-        │  │ • Image 取得  │  │ • CSV 取得 (Drive)         │  │
-        │  │ • User 情報   │  │ • CSV パース               │  │
-        │  │ • orchestrate │  │ • 重複チェック             │  │
-        │  └────────┬──────┘  │ • Sheets 追記             │  │
-        │           │         │ • ログ記録                 │  │
-        │  ┌────────┼──────────────────────────────┐      │  │
-        │  ▼        ▼        ▼           ▼          ▼      │  │
-        │ Gemini  Sheets   Drive       Sheets     Sheets   │  │
-        │  API    (receipts) API     (bank trans) (logs)   │  │
-        └────────────────────────────────────────────────┘
+        │  ┌────────▼──────┐  ┌▼─────────────────────────────────┐  │
+        │  │ lineHandler   │  │ bank/cardTransactionImporter      │  │
+        │  ├───────────────┤  ├──────────────────────────────────┤  │
+        │  │ • Image 取得  │  │ • CSV 取得 (Drive)               │  │
+        │  │ • User 情報   │  │ • CSV パース                     │  │
+        │  │ • orchestrate │  │ • 重複チェック                   │  │
+        │  └────────┬──────┘  │ • Sheets 追記                   │  │
+        │           │         │ • ログ記録                       │  │
+        │  ┌────────┼─────────────────────────────────────┐    │  │
+        │  ▼        ▼        ▼        ▼           ▼         ▼   │  │
+        │ Gemini  Sheets  Drive    Sheets       Sheets    Sheets │  │
+        │  API  (receipts) API  (bank trans) (card trans) (logs) │  │
+        └──────────────────────────────────────────────────────┘
 ```
 
 ## コンポーネント詳細
 
 ### 1. Cloud Run (Express Server)
 
-**役割:** LINE Webhook と銀行インポートリクエストを受け取り、各サービスを調整
+**役割:** LINE Webhook・銀行インポート・カードインポートリクエストを受け取り、各サービスを調整
 
 **エンドポイント:**
 - `POST /webhook` — LINE のイベント受信（middleware で署名検証）
 - `POST /bank/import` — 銀行取引 CSV インポート
+- `POST /card/import` — カード利用明細 CSV インポート
 - `GET /health` — ヘルスチェック
 
 **環境変数:**
@@ -60,8 +62,10 @@ GEMINI_API_KEY               # Gemini API 認証
 SPREADSHEET_ID               # Google Sheets ID
 SHEET_NAME                   # receipts シート名（default: receipts）
 BANK_TRANS_SHEET_NAME        # 銀行取引シート名（default: bank trans）
+CARD_TRANS_SHEET_NAME        # カード取引シート名（default: card trans）
 LOGS_SHEET_NAME              # ログシート名（default: logs）
 BANK_FOLDER_ID               # 銀行 CSV を置く Google Drive フォルダ ID
+CARD_FOLDER_ID               # カード CSV を置く Google Drive フォルダ ID
 GOOGLE_SERVICE_ACCOUNT_JSON  # GCP サービスアカウント認証情報
 ```
 
@@ -136,33 +140,45 @@ Event 受信
 
 ---
 
-### 5. 銀行取引インポート
+### 5. 銀行取引インポート・カード利用明細インポート
 
-#### フロー
+#### 銀行取引フロー（`POST /bank/import`）
 
 ```
-POST /bank/import
-  ↓
 [マッピング設定読み込み]
   └─ Google Drive: bank_mapping.json
         → {bankName, encoding, skipHeaderRow, skipFooterRow, columns}
   ↓
-[CSV ファイル一覧取得]
-  └─ bankDriveHelper: listCsvFiles(folderId)
-  ↓
-[既存トランザクション取得]
-  └─ bankTransactionDedup: getExistingTransactions(spreadsheetId)
+[CSV ファイル一覧取得] → [既存トランザクション取得]
   ↓
 [各 CSV ファイルを処理]
-  ├─ ダウンロード (Drive)
   ├─ パース (bankCsvParser)
   │    ├─ Shift-JIS デコード (iconv-lite)
-  │    ├─ 半角カナ→全角変換
-  │    └─ NFC 正規化
-  ├─ 重複チェック (bankTransactionDedup)
+  │    ├─ 半角カナ→全角変換・NFC 正規化
+  │    └─ 年月日分割カラム対応
+  ├─ 重複チェック: 取引日 + 金額 + 摘要 + 残高
   ├─ Sheets 追記 (bank trans シート)
   ├─ ファイル移動 (成功→処理済み / 失敗→要確認)
-  └─ ログ記録 (logs シート)
+  └─ ログ記録 (logs シート、処理名: "bank trans")
+```
+
+#### カード利用明細フロー（`POST /card/import`）
+
+```
+[マッピング設定読み込み]
+  └─ Google Drive: card_mapping.json
+        → {cardName, encoding, skipHeaderRow, skipFooterRow, columns}
+  ↓
+[CSV ファイル一覧取得] → [既存トランザクション取得]
+  ↓
+[各 CSV ファイルを処理]
+  ├─ パース (cardCsvParser)
+  │    └─ encoding 指定に対応（楽天カードは UTF-8）
+  ├─ 重複チェック: 利用日 + 利用店名 + 利用者 + 利用金額
+  │    ※ファイル内の重複はすべて取り込み、Sheets 既存データのみスキップ
+  ├─ Sheets 追記 (card trans シート)
+  ├─ ファイル移動 (成功→処理済み / 失敗→要確認)
+  └─ ログ記録 (logs シート、処理名: "card trans")
 ```
 
 #### bank trans シートのレコード形式
@@ -170,6 +186,12 @@ POST /bank/import
 | A | B | C | D | E | F | G | H |
 |---|---|---|---|---|---|---|---|
 | 取引日 | 金額 | 区分 | 残高 | 摘要 | コメント | カテゴリ（自動）| 銀行名 |
+
+#### card trans シートのレコード形式
+
+| A | B | C | D | E | F | G | H | I |
+|---|---|---|---|---|---|---|---|---|
+| 利用日 | 利用店名・商品名 | 利用者 | 支払方法 | 利用金額 | 手数料/利息 | 支払総額 | 支払月 | カード名 |
 
 #### logs シートのレコード形式
 

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -27,23 +27,37 @@ receipt-log/
 │   │       Drive から CSV 取得 → パース → 重複チェック → Sheets 追記
 │   │
 │   ├── bankCsvParser.js
-│   │   └─ CSV パース（Shift-JIS 対応、半角カナ全角変換、NFC 正規化）
+│   │   └─ 銀行 CSV パース（Shift-JIS 対応、半角カナ全角変換、NFC 正規化）
 │   │       マッピング設定 (bank_mapping.json) を使用して列を抽出
 │   │
 │   ├── bankTransactionDedup.js
-│   │   └─ 既存トランザクションとの重複チェック
+│   │   └─ 銀行取引の重複チェック
 │   │       照合キー: 取引日 + 金額 + 摘要 + 残高
 │   │
 │   ├── bankDriveHelper.js
-│   │   └─ Google Drive から CSV 一覧取得・ダウンロード・フォルダ移動
+│   │   └─ Google Drive から CSV 一覧取得・ダウンロード・フォルダ移動（bank/card 共用）
+│   │
+│   ├── cardTransactionImporter.js
+│   │   └─ カード取引インポートのオーケストレーション
+│   │       Drive から CSV 取得 → パース → 重複チェック → Sheets 追記
+│   │
+│   ├── cardCsvParser.js
+│   │   └─ カード CSV パース・card_mapping.json 読み込み
+│   │
+│   ├── cardTransactionDedup.js
+│   │   └─ カード取引の重複チェック
+│   │       照合キー: 利用日 + 利用店名 + 利用者 + 利用金額
+│   │       ※ファイル内重複はすべて取り込み、Sheets 既存データのみスキップ
 │   │
 │   └── logger.js
 │       └─ logs シートへの処理結果記録
 │           範囲: {LOGS_SHEET_NAME}!A:I
 │
 ├── conf/
-│   └── bank_mapping/
-│       └── saitamaresona.json   # 銀行マッピングサンプル
+│   ├── bank_mapping/
+│   │   └── saitamaresona.json   # 銀行マッピングサンプル
+│   └── card_mapping/
+│       └── rakuten.json         # 楽天カード用マッピングサンプル
 │
 ├── package.json
 │   └─ 依存関係（@line/bot-sdk, googleapis, @google/generative-ai, iconv-lite）
@@ -76,6 +90,8 @@ receipt-log/
 | `BANK_TRANS_SHEET_NAME` | 銀行取引シート名（default: bank trans）| Google Sheets タブ名 |
 | `LOGS_SHEET_NAME` | ログシート名（default: logs）| Google Sheets タブ名 |
 | `BANK_FOLDER_ID` | 銀行 CSV フォルダ ID | Drive の URL: `/folders/{ID}` |
+| `CARD_FOLDER_ID` | カード CSV フォルダ ID | Drive の URL: `/folders/{ID}` |
+| `CARD_TRANS_SHEET_NAME` | カード取引シート名（default: card trans）| Google Sheets タブ名 |
 | `GOOGLE_SERVICE_ACCOUNT_JSON` | GCP サービスアカウント認証 | gcloud iam service-accounts keys create |
 
 ---
@@ -167,12 +183,16 @@ await sheets.spreadsheets.values.append({
 });
 ```
 
-### 銀行インポートのローカルテスト
+### 銀行・カードインポートのローカルテスト
 
 ```bash
 curl -X POST http://localhost:8080/bank/import \
   -H "Content-Type: application/json" \
   -d '{"spreadsheetId": "...", "bankFolderId": "..."}'
+
+curl -X POST http://localhost:8080/card/import \
+  -H "Content-Type: application/json" \
+  -d '{"spreadsheetId": "...", "cardFolderId": "..."}'
 ```
 
 ---
@@ -216,6 +236,20 @@ POST /bank/import
       └─ 成功 → 「処理済み」フォルダへ移動・logs に記録
 ```
 
+### カードインポート（/card/import）
+
+```
+POST /card/import
+  │
+  ├─ card_mapping.json が見つからない → 400 エラー
+  ├─ CSV ファイルなし → "処理対象なし" で 200
+  │
+  └─ 各 CSV ファイル
+      ├─ パース失敗 → 「要確認」フォルダへ移動・logs に記録
+      └─ 成功（ファイル内重複はすべて取り込み、Sheets 既存のみスキップ）
+             → 「処理済み」フォルダへ移動・logs に記録
+```
+
 ---
 
 ## テストチェックリスト
@@ -232,6 +266,14 @@ POST /bank/import
 - [ ] bank trans シートに行が追記される（H 列に銀行名）
 - [ ] logs シートに処理結果が記録される（B 列に "bank trans"、C 列に銀行名）
 - [ ] 重複行が除外される
+- [ ] 処理済み CSV が「処理済み」フォルダへ移動する
+
+### カードインポート機能
+- [ ] `POST /card/import` でエラーなく完了する
+- [ ] card trans シートに行が追記される（I 列にカード名）
+- [ ] logs シートに処理結果が記録される（B 列に "card trans"、C 列にカード名）
+- [ ] ファイル内の重複行がすべて取り込まれる
+- [ ] Sheets 既存データと一致する行のみスキップされる
 - [ ] 処理済み CSV が「処理済み」フォルダへ移動する
 
 ---

--- a/src/cardCsvParser.js
+++ b/src/cardCsvParser.js
@@ -1,0 +1,120 @@
+const { google } = require("googleapis");
+const { downloadFile } = require("./bankDriveHelper");
+const iconv = require("iconv-lite");
+
+const MAPPING_FILENAME = "card_mapping.json";
+
+/**
+ * フォルダから card_mapping.json をダウンロード
+ * @param {string} cardFolderId
+ * @returns {Promise<Object>}
+ */
+async function loadCardMapping(cardFolderId) {
+  try {
+    const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON);
+    const auth = new google.auth.GoogleAuth({
+      credentials,
+      scopes: ["https://www.googleapis.com/auth/drive"],
+    });
+    const drive = google.drive({ version: "v3", auth });
+
+    const response = await drive.files.list({
+      q: `'${cardFolderId}' in parents and name='${MAPPING_FILENAME}' and trashed=false`,
+      spaces: "drive",
+      fields: "files(id)",
+      pageSize: 1,
+    });
+
+    if (!response.data.files || response.data.files.length === 0) {
+      throw new Error(`${MAPPING_FILENAME} が見つかりません`);
+    }
+
+    const buffer = await downloadFile(response.data.files[0].id);
+    return JSON.parse(buffer.toString("utf-8"));
+  } catch (err) {
+    throw new Error(`マッピング設定の読み込みエラー: ${err.message}`);
+  }
+}
+
+/**
+ * カード利用明細 CSV をパースしてオブジェクト配列に変換
+ * @param {Buffer} csvBuffer
+ * @param {Object} mapping
+ * @returns {Array<Object>}
+ */
+function parseCardCSV(csvBuffer, mapping) {
+  const encoding = mapping.encoding || "utf-8";
+  const csv = iconv.decode(csvBuffer, encoding);
+  const lines = csv.split("\n").filter((line) => line.trim());
+
+  if (lines.length === 0) return [];
+
+  const startIndex = mapping.skipHeaderRow ? 1 : 0;
+  const endIndex = mapping.skipFooterRow ? lines.length - 1 : lines.length;
+  const transactions = [];
+
+  for (let i = startIndex; i < endIndex; i++) {
+    const values = parseCSVLine(lines[i]);
+    const transaction = extractCardData(values, mapping.columns);
+    if (transaction) transactions.push(transaction);
+  }
+
+  return transactions;
+}
+
+/**
+ * CSV の 1 行をパース（クォート対応）
+ */
+function parseCSVLine(line) {
+  const result = [];
+  let current = "";
+  let insideQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === '"') {
+      if (insideQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        insideQuotes = !insideQuotes;
+      }
+    } else if (char === "," && !insideQuotes) {
+      result.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current.trim());
+  return result;
+}
+
+/**
+ * マッピングを適用してカード取引データを抽出
+ * @param {Array<string>} values
+ * @param {Object} columns
+ * @returns {Object|null}
+ */
+function extractCardData(values, columns) {
+  const usageDate = values[columns["利用日"]]?.trim();
+  const storeName = values[columns["利用店名"]]?.trim();
+  const amount = values[columns["利用金額"]]?.trim();
+
+  // 必須項目が揃わない行はスキップ
+  if (!usageDate || !storeName || !amount) return null;
+
+  return {
+    usageDate,
+    storeName,
+    user: values[columns["利用者"]]?.trim() || "",
+    paymentMethod: values[columns["支払方法"]]?.trim() || "",
+    amount: parseFloat(amount.replace(/[^0-9.-]/g, "")) || 0,
+    fee: parseFloat((values[columns["手数料/利息"]]?.trim() || "0").replace(/[^0-9.-]/g, "")) || 0,
+    totalAmount: parseFloat((values[columns["支払総額"]]?.trim() || "0").replace(/[^0-9.-]/g, "")) || 0,
+    paymentMonth: values[columns["支払月"]]?.trim() || "",
+  };
+}
+
+module.exports = { loadCardMapping, parseCardCSV };

--- a/src/cardTransactionDedup.js
+++ b/src/cardTransactionDedup.js
@@ -1,0 +1,74 @@
+const { google } = require("googleapis");
+
+const SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
+
+function getAuth() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON);
+  return new google.auth.GoogleAuth({ credentials, scopes: SCOPES });
+}
+
+/**
+ * スプレッドシートから既存のカード取引一覧を取得
+ * @param {string} spreadsheetId
+ * @param {string} sheetName
+ * @returns {Promise<Array>}
+ */
+async function getExistingCardTransactions(spreadsheetId, sheetName) {
+  const auth = getAuth();
+  const sheets = google.sheets({ version: "v4", auth });
+
+  try {
+    const response = await sheets.spreadsheets.values.get({
+      spreadsheetId,
+      range: `${sheetName}!A:E`, // 利用日(A)、利用店名(B)、利用者(C)、支払方法(D)、利用金額(E)
+    });
+
+    const rows = response.data.values || [];
+    return rows.slice(1).map((row) => ({
+      usageDate: row[0] || "",
+      storeName: row[1] || "",
+      user: row[2] || "",
+      amount: parseFloat(row[4]) || 0,
+    }));
+  } catch (err) {
+    console.error("既存カード取引取得エラー:", err);
+    return [];
+  }
+}
+
+/**
+ * 新しい取引が既存と重複するかチェック
+ * キー: 利用日 + 利用店名 + 利用者 + 利用金額
+ */
+function isCardDuplicate(newTx, existingTransactions) {
+  return existingTransactions.some(
+    (existing) =>
+      existing.usageDate === newTx.usageDate &&
+      existing.storeName === newTx.storeName &&
+      existing.user === newTx.user &&
+      existing.amount === newTx.amount
+  );
+}
+
+/**
+ * ファイル内の重複はそのまま取り込み、スプレッドシート既存データと一致する場合のみスキップ
+ * @param {Array<Object>} newTransactions - ファイルから読み込んだ全取引
+ * @param {Array<Object>} existingTransactions - スプレッドシートの既存取引
+ * @returns {{ unique: Array, duplicate: Array }}
+ */
+function filterCardDuplicates(newTransactions, existingTransactions) {
+  const unique = [];
+  const duplicate = [];
+
+  newTransactions.forEach((tx) => {
+    if (isCardDuplicate(tx, existingTransactions)) {
+      duplicate.push(tx);
+    } else {
+      unique.push(tx);
+    }
+  });
+
+  return { unique, duplicate };
+}
+
+module.exports = { getExistingCardTransactions, filterCardDuplicates };

--- a/src/cardTransactionImporter.js
+++ b/src/cardTransactionImporter.js
@@ -1,0 +1,204 @@
+const { google } = require("googleapis");
+const { listCsvFiles, downloadFile, moveFile } = require("./bankDriveHelper");
+const { loadCardMapping, parseCardCSV } = require("./cardCsvParser");
+const { getExistingCardTransactions, filterCardDuplicates } = require("./cardTransactionDedup");
+const { logResult } = require("./logger");
+
+const SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
+
+function getAuth() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON);
+  return new google.auth.GoogleAuth({ credentials, scopes: SCOPES });
+}
+
+/**
+ * サブフォルダを取得または作成
+ */
+async function getOrCreateSubfolder(auth, parentFolderId, folderName) {
+  const drive = google.drive({ version: "v3", auth });
+
+  const response = await drive.files.list({
+    q: `'${parentFolderId}' in parents and name='${folderName}' and mimeType='application/vnd.google-apps.folder' and trashed=false`,
+    spaces: "drive",
+    fields: "files(id)",
+    pageSize: 1,
+  });
+
+  if (response.data.files && response.data.files.length > 0) {
+    return response.data.files[0].id;
+  }
+
+  const createResponse = await drive.files.create({
+    requestBody: {
+      name: folderName,
+      mimeType: "application/vnd.google-apps.folder",
+      parents: [parentFolderId],
+    },
+    fields: "id",
+  });
+
+  return createResponse.data.id;
+}
+
+/**
+ * カード利用明細 CSV をスプレッドシートにインポート
+ * @param {string} spreadsheetId
+ * @param {string} cardFolderId
+ * @returns {Promise<Object>}
+ */
+async function importCardTransactions(spreadsheetId, cardFolderId) {
+  const timestamp = new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
+  const results = [];
+
+  try {
+    const mapping = await loadCardMapping(cardFolderId);
+    const cardName = mapping.cardName || "不明";
+
+    const csvFiles = await listCsvFiles(cardFolderId);
+
+    if (csvFiles.length === 0) {
+      return {
+        status: "success",
+        message: "処理対象の CSV ファイルがありません",
+        timestamp,
+        results: [],
+      };
+    }
+
+    const cardTransSheetName = process.env.CARD_TRANS_SHEET_NAME || "card trans";
+    const existingTransactions = await getExistingCardTransactions(spreadsheetId, cardTransSheetName);
+
+    const driveAuth = new google.auth.GoogleAuth({
+      credentials: JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON),
+      scopes: ["https://www.googleapis.com/auth/drive"],
+    });
+    const successFolderId = await getOrCreateSubfolder(driveAuth, cardFolderId, "処理済み");
+    const failureFolderId = await getOrCreateSubfolder(driveAuth, cardFolderId, "要確認");
+
+    for (const file of csvFiles) {
+      const fileResult = await processSingleFile(
+        file,
+        spreadsheetId,
+        mapping,
+        cardName,
+        existingTransactions,
+        successFolderId,
+        failureFolderId,
+        timestamp
+      );
+      results.push(fileResult);
+    }
+
+    const successCount = results.filter((r) => r.status === "success").length;
+    const failureCount = results.filter((r) => r.status === "failure").length;
+
+    return {
+      status: "completed",
+      message: `${successCount}ファイル成功、${failureCount}ファイル失敗`,
+      timestamp,
+      results,
+    };
+  } catch (err) {
+    console.error("カードインポート処理エラー:", err);
+    return { status: "error", message: err.message, timestamp, results };
+  }
+}
+
+/**
+ * 単一 CSV ファイルを処理
+ */
+async function processSingleFile(
+  file,
+  spreadsheetId,
+  mapping,
+  cardName,
+  existingTransactions,
+  successFolderId,
+  failureFolderId,
+  timestamp
+) {
+  const fileResult = {
+    fileName: file.name,
+    status: "failure",
+    totalRows: 0,
+    importedRows: 0,
+    duplicateRows: 0,
+    errorMessage: "",
+  };
+
+  try {
+    const csvBuffer = await downloadFile(file.id);
+    const transactions = parseCardCSV(csvBuffer, mapping);
+    fileResult.totalRows = transactions.length;
+
+    // ファイル内の重複はそのまま、スプレッドシート既存データのみスキップ
+    const { unique, duplicate } = filterCardDuplicates(transactions, existingTransactions);
+    fileResult.duplicateRows = duplicate.length;
+
+    if (unique.length > 0) {
+      await appendCardTransactionsToSheet(spreadsheetId, cardName, unique);
+      fileResult.importedRows = unique.length;
+
+      // 次ファイル処理時の重複チェック用に追加
+      existingTransactions.push(...unique);
+    }
+
+    await moveFile(file.id, successFolderId);
+    fileResult.status = "success";
+
+    await logResult(spreadsheetId, {
+      processName: "card trans",
+      bankName: cardName,
+      timestamp,
+      ...fileResult,
+    });
+  } catch (err) {
+    console.error(`ファイル処理エラー (${file.name}):`, err);
+    fileResult.errorMessage = err.message;
+
+    try {
+      await moveFile(file.id, failureFolderId);
+      await logResult(spreadsheetId, {
+        processName: "card trans",
+        bankName: cardName,
+        timestamp,
+        ...fileResult,
+      });
+    } catch (moveErr) {
+      console.error(`ファイル移動エラー (${file.name}):`, moveErr);
+    }
+  }
+
+  return fileResult;
+}
+
+/**
+ * カード取引をスプレッドシートに追記
+ */
+async function appendCardTransactionsToSheet(spreadsheetId, cardName, transactions) {
+  const auth = getAuth();
+  const sheets = google.sheets({ version: "v4", auth });
+  const sheetName = process.env.CARD_TRANS_SHEET_NAME || "card trans";
+
+  const values = transactions.map((t) => [
+    t.usageDate,
+    t.storeName,
+    t.user,
+    t.paymentMethod,
+    t.amount,
+    t.fee,
+    t.totalAmount,
+    t.paymentMonth,
+    cardName,
+  ]);
+
+  await sheets.spreadsheets.values.append({
+    spreadsheetId,
+    range: `${sheetName}!A:I`,
+    valueInputOption: "USER_ENTERED",
+    insertDataOption: "INSERT_ROWS",
+    requestBody: { values },
+  });
+}
+
+module.exports = { importCardTransactions };

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const express = require("express");
 const { middleware, Client } = require("@line/bot-sdk");
 const { handleEvent } = require("./lineHandler");
 const { importBankTransactions } = require("./bankTransactionImporter");
+const { importCardTransactions } = require("./cardTransactionImporter");
 
 const config = {
   channelSecret: process.env.LINE_CHANNEL_SECRET,
@@ -53,6 +54,39 @@ app.post("/bank/import", async (req, res) => {
     res.status(200).json(result);
   } catch (err) {
     console.error("/bank/import エラー:", err);
+    res.status(500).json({
+      status: "error",
+      message: err.message,
+    });
+  }
+});
+
+/**
+ * カード利用明細CSVのインポート
+ * POST /card/import
+ * リクエストボディ: { spreadsheetId: "...", cardFolderId: "..." }
+ */
+app.post("/card/import", async (req, res) => {
+  try {
+    const spreadsheetId = req.body.spreadsheetId || process.env.SPREADSHEET_ID;
+    const cardFolderId = req.body.cardFolderId || process.env.CARD_FOLDER_ID;
+
+    if (!spreadsheetId || !cardFolderId) {
+      return res.status(400).json({
+        status: "error",
+        message: "spreadsheetId または cardFolderId が指定されていません",
+      });
+    }
+
+    console.log(
+      `カード取引インポート開始: spreadsheetId=${spreadsheetId}, cardFolderId=${cardFolderId}`
+    );
+
+    const result = await importCardTransactions(spreadsheetId, cardFolderId);
+
+    res.status(200).json(result);
+  } catch (err) {
+    console.error("/card/import エラー:", err);
     res.status(500).json({
       status: "error",
       message: err.message,


### PR DESCRIPTION
## 概要

銀行取引インポートと同様に、カード利用明細 CSV を Google Drive 経由でスプレッドシートにインポートする機能を追加。

Closes #5

## 新規ファイル

| ファイル | 説明 |
|---------|------|
| `src/cardCsvParser.js` | CSV パース・card_mapping.json 読み込み |
| `src/cardTransactionDedup.js` | 重複チェック |
| `src/cardTransactionImporter.js` | インポート処理のオーケストレーション |
| `conf/card_mapping/rakuten.json` | 楽天カード用マッピングサンプル |

## 変更ファイル

- `src/index.js` — `/card/import` エンドポイント追加
- `.env.example` — `CARD_FOLDER_ID`・`CARD_TRANS_SHEET_NAME` 追加
- `README.md` / `docs/` — カードインポート機能を反映

## card trans シートのカラム構成（A:I）

| A | B | C | D | E | F | G | H | I |
|---|---|---|---|---|---|---|---|---|
| 利用日 | 利用店名・商品名 | 利用者 | 支払方法 | 利用金額 | 手数料/利息 | 支払総額 | 支払月 | カード名 |

## 重複チェックの仕様

- **ファイル内の重複はすべて取り込む**（同一ファイル内の同一明細も両方インポート）
- スプレッドシートの既存データと一致する場合のみスキップ
- 照合キー: 利用日 + 利用店名 + 利用者 + 利用金額

🤖 Generated with [Claude Code](https://claude.com/claude-code)