### PR TITLE
feat: カテゴリ自動判定機能を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ BANK_TRANS_SHEET_NAME=bank trans
 # カード取引インポート
 CARD_FOLDER_ID=your_card_folder_id
 CARD_TRANS_SHEET_NAME=card trans
+
+# カテゴリ自動判定
+CATEGORY_RULES_SHEET_NAME=category rules

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ LINE グループ内で共有されたレシート画像を自動で解析し、
 - **スプレッドシート統合** — リアルタイムでレシート情報を集計できる
 - **銀行取引インポート** — Shift-JIS の CSV に対応、銀行ごとのマッピング設定で複数口座を管理
 - **カード利用明細インポート** — 楽天カード等の CSV に対応、カードごとのマッピング設定で複数カードを管理
+- **カテゴリ自動判定** — ルールベース＋Gemini のハイブリッドで全トランザクションにカテゴリを付与。既知の店名はルールで即判定し、未知の店名のみ Gemini に問い合わせて `category rules` シートに蓄積
 
 ## 使い方
 
@@ -87,6 +88,7 @@ src/
 ├── cardTransactionImporter.js # カード取引インポート処理のオーケストレーション
 ├── cardCsvParser.js           # カード CSV パース・card_mapping.json 読み込み
 ├── cardTransactionDedup.js    # カード取引の重複チェック
+├── categoryService.js         # カテゴリ自動判定（ルール照合 + Gemini バッチ）
 └── logger.js                  # logs シートへの処理結果記録
 
 conf/

--- a/docs/API.md
+++ b/docs/API.md
@@ -292,7 +292,7 @@ Content-Type: application/json
 
 ### receipts シート（レシート記録）
 
-追記範囲: `{SHEET_NAME}!A:J`
+追記範囲: `{SHEET_NAME}!A:K`
 
 | 列 | タイプ | 項目 | 例 |
 |----|--------|------|----|
@@ -306,6 +306,7 @@ Content-Type: application/json
 | H | String | 支払い方法 | `現金` |
 | I | String | 品目（改行区切り）| `おにぎり 150円\nコーヒー 180円` |
 | J | String | 備考 | `支払い日時はレシートから読み取れなかったため受信日時を使用` |
+| K | String | カテゴリ（自動）| `食費` |
 
 ### bank trans シート（銀行取引）
 
@@ -324,7 +325,7 @@ Content-Type: application/json
 
 ### card trans シート（カード利用明細）
 
-追記範囲: `{CARD_TRANS_SHEET_NAME}!A:I`
+追記範囲: `{CARD_TRANS_SHEET_NAME}!A:J`
 
 | 列 | タイプ | 項目 | 例 |
 |----|--------|------|----|
@@ -337,6 +338,25 @@ Content-Type: application/json
 | G | Number | 支払総額 | `3002` |
 | H | String | 支払月 | `5月` |
 | I | String | カード名 | `楽天カード` |
+| J | String | カテゴリ（自動）| `食費` |
+
+### category rules シート（カテゴリルール）
+
+追記範囲: `{CATEGORY_RULES_SHEET_NAME}!A:D`
+
+| 列 | タイプ | 項目 | 例 |
+|----|--------|------|----|
+| A | String | キーワード | `セブン` |
+| B | String | カテゴリ | `食費` |
+| C | String | 登録日時 | `2026/04/10 15:33:01` |
+| D | String | ソース | `Gemini` |
+
+**カテゴリ一覧:** `食費 / 日用品 / 交通費 / 通信費 / 光熱費 / 医療 / 娯楽 / 衣類 / 教育 / 保険 / 住居費 / その他`
+
+**動作仕様:**
+- 未知の店名が出現した場合、Gemini が判定してこのシートに自動追加
+- キーワードは部分一致で照合（大文字・小文字区別なし）
+- 手動でルールを追加・修正することも可能
 
 ### logs シート（インポート処理ログ）
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,6 +64,7 @@ SHEET_NAME                   # receipts シート名（default: receipts）
 BANK_TRANS_SHEET_NAME        # 銀行取引シート名（default: bank trans）
 CARD_TRANS_SHEET_NAME        # カード取引シート名（default: card trans）
 LOGS_SHEET_NAME              # ログシート名（default: logs）
+CATEGORY_RULES_SHEET_NAME    # カテゴリルールシート名（default: category rules）
 BANK_FOLDER_ID               # 銀行 CSV を置く Google Drive フォルダ ID
 CARD_FOLDER_ID               # カード CSV を置く Google Drive フォルダ ID
 GOOGLE_SERVICE_ACCOUNT_JSON  # GCP サービスアカウント認証情報
@@ -97,9 +98,13 @@ Event 受信
   [支払い日時フォールバック]
       └─ paymentDate が null → 受信日時を使用、備考にメモ
       ↓
+  [カテゴリ自動判定]
+      └─ categorizeTransactions(spreadsheetId, [storeName])
+            → ルール照合（部分一致）→ 未知の場合 Gemini バッチ処理
+      ↓
   [Sheets に記録]
       └─ logToSheet({receivedAt, paymentDate, userId, displayName,
-                      groupId, storeName, totalAmount, paymentMethod, items, remarks})
+                      groupId, storeName, totalAmount, paymentMethod, items, remarks, categoryAuto})
       ↓
   [返信を送信]
       └─ replyMessage(replyToken, text)
@@ -134,13 +139,43 @@ Event 受信
 
 **receipts シートのレコード形式:**
 
-| A | B | C | D | E | F | G | H | I | J |
-|---|---|---|---|---|---|---|---|---|---|
-| 受信日時 | 支払い日時 | LINE UserID | 表示名 | グループID | 店名 | 合計金額 | 支払い方法 | 品目 | 備考 |
+| A | B | C | D | E | F | G | H | I | J | K |
+|---|---|---|---|---|---|---|---|---|---|---|
+| 受信日時 | 支払い日時 | LINE UserID | 表示名 | グループID | 店名 | 合計金額 | 支払い方法 | 品目 | 備考 | カテゴリ |
 
 ---
 
-### 5. 銀行取引インポート・カード利用明細インポート
+### 5. カテゴリサービス (`src/categoryService.js`)
+
+**役割:** レシート・銀行・カードの全トランザクションにカテゴリを自動付与
+
+**フロー:**
+
+```
+[category rules シートからルール読み込み]
+  ↓
+[各トランザクションをルール照合（部分一致）]
+  ├─ 一致 → カテゴリ確定
+  └─ 不一致 → 未知リストへ
+      ↓
+  [未知の店名を Gemini バッチ処理]
+      └─ 1リクエストで複数店名を一括判定
+      ↓
+  [新規ルールを category rules シートに追記]
+      └─ {キーワード, カテゴリ, 登録日時, "Gemini"}
+```
+
+**カテゴリ一覧:**
+`食費 / 日用品 / 交通費 / 通信費 / 光熱費 / 医療 / 娯楽 / 衣類 / 教育 / 保険 / 住居費 / その他`
+
+**設計のポイント:**
+- 既知の店名はルールで即判定（Gemini 不使用）→ RPD 節約
+- 未知の店名のみ Gemini バッチ処理（複数をまとめて 1 リクエスト）
+- 判定結果を自動で rules シートに蓄積 → 次回以降はルール照合で完結
+
+---
+
+### 6. 銀行取引インポート・カード利用明細インポート
 
 #### 銀行取引フロー（`POST /bank/import`）
 
@@ -157,7 +192,9 @@ Event 受信
   │    ├─ 半角カナ→全角変換・NFC 正規化
   │    └─ 年月日分割カラム対応
   ├─ 重複チェック: 取引日 + 金額 + 摘要 + 残高
-  ├─ Sheets 追記 (bank trans シート)
+  ├─ カテゴリ自動判定 (categoryService)
+  │    └─ ルール照合 → 未知の店名のみ Gemini バッチ → category rules に蓄積
+  ├─ Sheets 追記 (bank trans シート、G 列にカテゴリ)
   ├─ ファイル移動 (成功→処理済み / 失敗→要確認)
   └─ ログ記録 (logs シート、処理名: "bank trans")
 ```
@@ -176,7 +213,9 @@ Event 受信
   │    └─ encoding 指定に対応（楽天カードは UTF-8）
   ├─ 重複チェック: 利用日 + 利用店名 + 利用者 + 利用金額
   │    ※ファイル内の重複はすべて取り込み、Sheets 既存データのみスキップ
-  ├─ Sheets 追記 (card trans シート)
+  ├─ カテゴリ自動判定 (categoryService)
+  │    └─ ルール照合 → 未知の店名のみ Gemini バッチ → category rules に蓄積
+  ├─ Sheets 追記 (card trans シート、J 列にカテゴリ)
   ├─ ファイル移動 (成功→処理済み / 失敗→要確認)
   └─ ログ記録 (logs シート、処理名: "card trans")
 ```
@@ -189,9 +228,19 @@ Event 受信
 
 #### card trans シートのレコード形式
 
-| A | B | C | D | E | F | G | H | I |
-|---|---|---|---|---|---|---|---|---|
-| 利用日 | 利用店名・商品名 | 利用者 | 支払方法 | 利用金額 | 手数料/利息 | 支払総額 | 支払月 | カード名 |
+| A | B | C | D | E | F | G | H | I | J |
+|---|---|---|---|---|---|---|---|---|---|
+| 利用日 | 利用店名・商品名 | 利用者 | 支払方法 | 利用金額 | 手数料/利息 | 支払総額 | 支払月 | カード名 | カテゴリ |
+
+#### category rules シートのレコード形式
+
+| A | B | C | D |
+|---|---|---|---|
+| キーワード | カテゴリ | 登録日時 | ソース |
+
+- **キーワード**: 店名の部分一致に使用する文字列
+- **カテゴリ**: `食費 / 日用品 / 交通費 / 通信費 / 光熱費 / 医療 / 娯楽 / 衣類 / 教育 / 保険 / 住居費 / その他`
+- **ソース**: `Gemini`（自動追加）または手動で入力
 
 #### logs シートのレコード形式
 

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -20,7 +20,7 @@ receipt-log/
 │   │
 │   ├── sheetsLogger.js
 │   │   └─ サービスアカウント認証で receipts シートに追記
-│   │       範囲: {SHEET_NAME}!A:J
+│   │       範囲: {SHEET_NAME}!A:K
 │   │
 │   ├── bankTransactionImporter.js
 │   │   └─ 銀行取引インポートのオーケストレーション
@@ -48,6 +48,12 @@ receipt-log/
 │   │   └─ カード取引の重複チェック
 │   │       照合キー: 利用日 + 利用店名 + 利用者 + 利用金額
 │   │       ※ファイル内重複はすべて取り込み、Sheets 既存データのみスキップ
+│   │
+│   ├── categoryService.js
+│   │   └─ カテゴリ自動判定（ルール照合 + Gemini バッチ）
+│   │       ① category rules シートからキーワードを読み込み部分一致で判定
+│   │       ② 未知の店名のみ Gemini に一括問い合わせ
+│   │       ③ 新規ルールを category rules シートに自動追記
 │   │
 │   └── logger.js
 │       └─ logs シートへの処理結果記録
@@ -92,6 +98,7 @@ receipt-log/
 | `BANK_FOLDER_ID` | 銀行 CSV フォルダ ID | Drive の URL: `/folders/{ID}` |
 | `CARD_FOLDER_ID` | カード CSV フォルダ ID | Drive の URL: `/folders/{ID}` |
 | `CARD_TRANS_SHEET_NAME` | カード取引シート名（default: card trans）| Google Sheets タブ名 |
+| `CATEGORY_RULES_SHEET_NAME` | カテゴリルールシート名（default: category rules）| Google Sheets タブ名 |
 | `GOOGLE_SERVICE_ACCOUNT_JSON` | GCP サービスアカウント認証 | gcloud iam service-accounts keys create |
 
 ---
@@ -176,7 +183,7 @@ const sheets = google.sheets({ version: "v4", auth });
 
 await sheets.spreadsheets.values.append({
   spreadsheetId,
-  range: `${SHEET_NAME}!A:J`,   // receipts: A:J / bank trans: A:H / logs: A:I
+  range: `${SHEET_NAME}!A:K`,   // receipts: A:K / bank trans: A:H / card trans: A:J / logs: A:I
   valueInputOption: "USER_ENTERED",
   insertDataOption: "INSERT_ROWS",
   requestBody: { values: [[...]] }
@@ -257,13 +264,15 @@ POST /card/import
 ### レシート機能
 - [ ] `npm run dev` が起動する
 - [ ] ngrok で LINE テストメッセージ送信 → Bot 返信確認
-- [ ] receipts シートに行が追記される（A:J 全カラム）
+- [ ] receipts シートに行が追記される（A:K 全カラム）
 - [ ] 支払い日時が読み取れない場合、J 列に備考が入る
 - [ ] グループ ID が E 列に記録される
+- [ ] K 列にカテゴリが記録される
 
 ### 銀行インポート機能
 - [ ] `POST /bank/import` でエラーなく完了する
 - [ ] bank trans シートに行が追記される（H 列に銀行名）
+- [ ] G 列にカテゴリが記録される
 - [ ] logs シートに処理結果が記録される（B 列に "bank trans"、C 列に銀行名）
 - [ ] 重複行が除外される
 - [ ] 処理済み CSV が「処理済み」フォルダへ移動する
@@ -271,10 +280,16 @@ POST /card/import
 ### カードインポート機能
 - [ ] `POST /card/import` でエラーなく完了する
 - [ ] card trans シートに行が追記される（I 列にカード名）
+- [ ] J 列にカテゴリが記録される
 - [ ] logs シートに処理結果が記録される（B 列に "card trans"、C 列にカード名）
 - [ ] ファイル内の重複行がすべて取り込まれる
 - [ ] Sheets 既存データと一致する行のみスキップされる
 - [ ] 処理済み CSV が「処理済み」フォルダへ移動する
+
+### カテゴリ自動判定
+- [ ] category rules シートのルールが照合される（部分一致）
+- [ ] 未知の店名は Gemini で判定される
+- [ ] 新規ルールが category rules シートに自動追記される
 
 ---
 

--- a/src/bankTransactionImporter.js
+++ b/src/bankTransactionImporter.js
@@ -6,6 +6,7 @@ const {
   filterDuplicates,
 } = require("./bankTransactionDedup");
 const { logResult } = require("./logger");
+const { categorizeTransactions } = require("./categoryService");
 
 const SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
 
@@ -172,8 +173,17 @@ async function processSingleFile(
     );
     fileResult.duplicateRows = duplicate.length;
 
-    // 新規トランザクションをスプレッドシートに追記
+    // 新規トランザクションにカテゴリを付与
     if (unique.length > 0) {
+      try {
+        const descriptions = unique.map((t) => t.description);
+        const categories = await categorizeTransactions(spreadsheetId, descriptions);
+        unique.forEach((t, i) => { t.categoryAuto = categories[i]; });
+      } catch (err) {
+        console.warn("銀行取引カテゴリ判定失敗:", err.message);
+        unique.forEach((t) => { t.categoryAuto = "その他"; });
+      }
+
       await appendTransactionsToSheet(spreadsheetId, bankName, unique);
       fileResult.importedRows = unique.length;
 

--- a/src/cardTransactionImporter.js
+++ b/src/cardTransactionImporter.js
@@ -3,6 +3,7 @@ const { listCsvFiles, downloadFile, moveFile } = require("./bankDriveHelper");
 const { loadCardMapping, parseCardCSV } = require("./cardCsvParser");
 const { getExistingCardTransactions, filterCardDuplicates } = require("./cardTransactionDedup");
 const { logResult } = require("./logger");
+const { categorizeTransactions } = require("./categoryService");
 
 const SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
 
@@ -136,6 +137,15 @@ async function processSingleFile(
     fileResult.duplicateRows = duplicate.length;
 
     if (unique.length > 0) {
+      try {
+        const descriptions = unique.map((t) => t.storeName);
+        const categories = await categorizeTransactions(spreadsheetId, descriptions);
+        unique.forEach((t, i) => { t.categoryAuto = categories[i]; });
+      } catch (err) {
+        console.warn("カード取引カテゴリ判定失敗:", err.message);
+        unique.forEach((t) => { t.categoryAuto = "その他"; });
+      }
+
       await appendCardTransactionsToSheet(spreadsheetId, cardName, unique);
       fileResult.importedRows = unique.length;
 
@@ -190,11 +200,12 @@ async function appendCardTransactionsToSheet(spreadsheetId, cardName, transactio
     t.totalAmount,
     t.paymentMonth,
     cardName,
+    t.categoryAuto ?? "",
   ]);
 
   await sheets.spreadsheets.values.append({
     spreadsheetId,
-    range: `${sheetName}!A:I`,
+    range: `${sheetName}!A:J`,
     valueInputOption: "USER_ENTERED",
     insertDataOption: "INSERT_ROWS",
     requestBody: { values },

--- a/src/categoryService.js
+++ b/src/categoryService.js
@@ -1,0 +1,161 @@
+const { GoogleGenerativeAI } = require("@google/generative-ai");
+const { google } = require("googleapis");
+
+const CATEGORIES = [
+  "食費", "日用品", "交通費", "通信費", "光熱費",
+  "医療", "娯楽", "衣類", "教育", "保険", "住居費", "その他",
+];
+const SCOPES = ["https://www.googleapis.com/auth/spreadsheets"];
+
+function getAuth() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON);
+  return new google.auth.GoogleAuth({ credentials, scopes: SCOPES });
+}
+
+/**
+ * category rules シートからルール一覧を取得
+ * @returns {Promise<Array<{keyword: string, category: string}>>}
+ */
+async function loadCategoryRules(spreadsheetId) {
+  const auth = getAuth();
+  const sheets = google.sheets({ version: "v4", auth });
+  const sheetName = process.env.CATEGORY_RULES_SHEET_NAME || "category rules";
+
+  try {
+    const response = await sheets.spreadsheets.values.get({
+      spreadsheetId,
+      range: `${sheetName}!A:B`,
+    });
+    const rows = response.data.values || [];
+    return rows.slice(1)
+      .filter((row) => row[0] && row[1])
+      .map((row) => ({ keyword: row[0].trim(), category: row[1].trim() }));
+  } catch (err) {
+    console.warn("category rules 読み込みエラー（シートが未作成の可能性）:", err.message);
+    return [];
+  }
+}
+
+/**
+ * ルールから部分一致でカテゴリを検索
+ * @param {string} description
+ * @param {Array<{keyword, category}>} rules
+ * @returns {string|null}
+ */
+function findCategoryByRule(description, rules) {
+  if (!description) return null;
+  const desc = description.toLowerCase();
+  const matched = rules.find((r) => desc.includes(r.keyword.toLowerCase()));
+  return matched ? matched.category : null;
+}
+
+/**
+ * Gemini に複数の摘要をまとめてカテゴリ判定させる
+ * @param {Array<{index: number, description: string}>} items
+ * @returns {Promise<Object>} { [index]: category }
+ */
+async function categorizeWithGemini(items) {
+  if (items.length === 0) return {};
+
+  const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+  const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
+
+  const prompt = `
+以下の取引の店名・摘要から、適切なカテゴリを1つ選んでください。
+カテゴリは必ず次の中から選んでください: ${CATEGORIES.join("、")}
+
+JSON配列のみを返してください（説明不要）:
+[{"index": 番号, "category": "カテゴリ名"}, ...]
+
+取引リスト:
+${JSON.stringify(items, null, 2)}
+`.trim();
+
+  try {
+    const result = await model.generateContent(prompt);
+    let text = result.response.text().trim().replace(/```(?:json)?\n?/g, "").trim();
+    const parsed = JSON.parse(text);
+    return Object.fromEntries(parsed.map((r) => [r.index, r.category]));
+  } catch (err) {
+    console.error("Gemini カテゴリ判定エラー:", err.message);
+    // 失敗時は全件「その他」
+    return Object.fromEntries(items.map((item) => [item.index, "その他"]));
+  }
+}
+
+/**
+ * 新しいルールを category rules シートに追記
+ * @param {string} spreadsheetId
+ * @param {Array<{keyword: string, category: string}>} newRules
+ */
+async function addNewRules(spreadsheetId, newRules) {
+  if (newRules.length === 0) return;
+
+  const auth = getAuth();
+  const sheets = google.sheets({ version: "v4", auth });
+  const sheetName = process.env.CATEGORY_RULES_SHEET_NAME || "category rules";
+  const timestamp = new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
+
+  const values = newRules.map((r) => [r.keyword, r.category, timestamp, "Gemini"]);
+
+  await sheets.spreadsheets.values.append({
+    spreadsheetId,
+    range: `${sheetName}!A:D`,
+    valueInputOption: "USER_ENTERED",
+    insertDataOption: "INSERT_ROWS",
+    requestBody: { values },
+  });
+}
+
+/**
+ * 摘要リストにカテゴリを付与して返す（メイン関数）
+ * - rules シートを部分一致で照合
+ * - 未ヒット分を Gemini にバッチ送信
+ * - 新規ルールを rules シートに追記
+ *
+ * @param {string} spreadsheetId
+ * @param {Array<string>} descriptions - 店名・摘要の配列
+ * @returns {Promise<Array<string>>} categories - 同順のカテゴリ配列
+ */
+async function categorizeTransactions(spreadsheetId, descriptions) {
+  const rules = await loadCategoryRules(spreadsheetId);
+  const categories = new Array(descriptions.length).fill(null);
+  const unknownItems = [];
+
+  // ① ルールで照合
+  descriptions.forEach((desc, i) => {
+    const category = findCategoryByRule(desc, rules);
+    if (category) {
+      categories[i] = category;
+    } else {
+      unknownItems.push({ index: i, description: desc || "" });
+    }
+  });
+
+  // ② 未ヒット分を Gemini でバッチ判定
+  if (unknownItems.length > 0) {
+    const geminiResult = await categorizeWithGemini(unknownItems);
+
+    // 新規ルールを収集（同じキーワードの重複を排除）
+    const newRules = [];
+    const addedKeywords = new Set(rules.map((r) => r.keyword.toLowerCase()));
+
+    unknownItems.forEach((item) => {
+      const category = geminiResult[item.index] ?? "その他";
+      categories[item.index] = category;
+
+      const keyword = item.description;
+      if (keyword && !addedKeywords.has(keyword.toLowerCase())) {
+        newRules.push({ keyword, category });
+        addedKeywords.add(keyword.toLowerCase());
+      }
+    });
+
+    // ③ 新規ルールを rules シートに追記
+    await addNewRules(spreadsheetId, newRules);
+  }
+
+  return categories.map((c) => c ?? "その他");
+}
+
+module.exports = { categorizeTransactions, CATEGORIES };

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,6 @@ const config = {
 
 const app = express();
 
-// ボディパーサーの設定
-app.use(express.json());
-
 app.post("/webhook", middleware(config), (req, res) => {
   // すぐにレスポンスを返す（LINE のタイムアウト防止）
   res.status(200).send("OK");
@@ -33,7 +30,7 @@ app.post("/webhook", middleware(config), (req, res) => {
  * POST /bank/import
  * リクエストボディ: { spreadsheetId: "...", bankFolderId: "..." }
  */
-app.post("/bank/import", async (req, res) => {
+app.post("/bank/import", express.json(), async (req, res) => {
   try {
     const spreadsheetId = req.body.spreadsheetId || process.env.SPREADSHEET_ID;
     const bankFolderId = req.body.bankFolderId || process.env.BANK_FOLDER_ID;
@@ -66,7 +63,7 @@ app.post("/bank/import", async (req, res) => {
  * POST /card/import
  * リクエストボディ: { spreadsheetId: "...", cardFolderId: "..." }
  */
-app.post("/card/import", async (req, res) => {
+app.post("/card/import", express.json(), async (req, res) => {
   try {
     const spreadsheetId = req.body.spreadsheetId || process.env.SPREADSHEET_ID;
     const cardFolderId = req.body.cardFolderId || process.env.CARD_FOLDER_ID;

--- a/src/lineHandler.js
+++ b/src/lineHandler.js
@@ -1,5 +1,6 @@
 const { parseReceipt } = require("./geminiParser");
 const { logToSheet } = require("./sheetsLogger");
+const { categorizeTransactions } = require("./categoryService");
 
 /**
  * LINE イベントを処理する
@@ -56,6 +57,16 @@ async function handleEvent(event, client) {
   const paymentDate = receipt.paymentDate ?? receivedAt;
   const remarks = receipt.paymentDate ? "" : "支払い日時はレシートから読み取れなかったため受信日時を使用";
 
+  // カテゴリ自動判定
+  let categoryAuto = "その他";
+  try {
+    const spreadsheetId = process.env.SPREADSHEET_ID;
+    const categories = await categorizeTransactions(spreadsheetId, [receipt.storeName ?? ""]);
+    categoryAuto = categories[0];
+  } catch (err) {
+    console.warn("カテゴリ判定失敗:", err.message);
+  }
+
   // スプレッドシートに記録
   try {
     await logToSheet({
@@ -69,6 +80,7 @@ async function handleEvent(event, client) {
       paymentMethod: receipt.paymentMethod,
       items: receipt.items,
       remarks,
+      categoryAuto,
     });
   } catch (err) {
     console.error("スプレッドシート記録失敗:", err);

--- a/src/sheetsLogger.js
+++ b/src/sheetsLogger.js
@@ -17,7 +17,7 @@ function getAuth() {
  * スプレッドシートに1行追記する
  * @param {{ receivedAt, paymentDate, userId, displayName, groupId, storeName, totalAmount, paymentMethod, items, remarks }} row
  */
-async function logToSheet({ receivedAt, paymentDate, userId, displayName, groupId, storeName, totalAmount, paymentMethod, items, remarks }) {
+async function logToSheet({ receivedAt, paymentDate, userId, displayName, groupId, storeName, totalAmount, paymentMethod, items, remarks, categoryAuto = "" }) {
   const auth = getAuth();
   const sheets = google.sheets({ version: "v4", auth });
 
@@ -33,12 +33,13 @@ async function logToSheet({ receivedAt, paymentDate, userId, displayName, groupI
       paymentMethod ?? "",
       items ?? "",
       remarks ?? "",
+      categoryAuto,
     ],
   ];
 
   await sheets.spreadsheets.values.append({
     spreadsheetId: SPREADSHEET_ID,
-    range: `${SHEET_NAME}!A:J`,
+    range: `${SHEET_NAME}!A:K`,
     valueInputOption: "USER_ENTERED",
     insertDataOption: "INSERT_ROWS",
     requestBody: { values },


### PR DESCRIPTION
## Summary

- `categoryService.js` を新規追加。ルールベース（部分一致）+ Gemini バッチのハイブリッドでカテゴリを自動判定
- レシート・銀行取引・カード利用明細の全トランザクションにカテゴリを付与
  - receipts シート: K 列にカテゴリ追加（A:K）
  - bank trans シート: G 列（既存）を自動入力（A:H）
  - card trans シート: J 列にカテゴリ追加（A:J）
- 未知の店名は Gemini で判定し、`category rules` シートに自動蓄積（次回以降はルールで即判定）
- `express.json()` をグローバル適用から `/bank/import`・`/card/import` のみに変更（LINE 署名検証の修正）

## Test plan

- [x] レシート送信後、receipts シートの K 列にカテゴリが記録されること
- [x] `/bank/import` 後、bank trans シートの G 列にカテゴリが記録されること
- [x] `/card/import` 後、card trans シートの J 列にカテゴリが記録されること
- [x] category rules シートの既存キーワードで部分一致判定が機能すること
- [x] 未知の店名が Gemini で判定され category rules に追記されること
- [x] LINE Webhook の署名検証が正常に動作すること（500 エラーが解消されていること）

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)