### PR TITLE
feat: 月別集計機能（LINE返信 + LIFF SPA）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,8 @@ CARD_TRANS_SHEET_NAME=card trans
 
 # カテゴリ自動判定
 CATEGORY_RULES_SHEET_NAME=category rules
+
+# 月別集計 SPA
+# LIFF アプリの URL（LINE Developers で登録後に設定）
+# 未設定の場合は LINE Bot のテキスト集計のみ返信（ボタンなし）
+LIFF_URL=https://liff.line.me/YOUR_LIFF_ID

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json ./
 RUN npm install --omit=dev
 
 COPY src/ ./src/
+COPY public/ ./public/
 
 ENV NODE_ENV=production
 ENV PORT=8080

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ LINE グループ内で共有されたレシート画像を自動で解析し、
 - **銀行取引インポート** — Shift-JIS の CSV に対応、銀行ごとのマッピング設定で複数口座を管理
 - **カード利用明細インポート** — 楽天カード等の CSV に対応、カードごとのマッピング設定で複数カードを管理
 - **カテゴリ自動判定** — ルールベース＋Gemini のハイブリッドで全トランザクションにカテゴリを付与。既知の店名はルールで即判定し、未知の店名のみ Gemini に問い合わせて `category rules` シートに蓄積
+- **月別集計** — 「集計」と投稿するとカテゴリ別支出・入金合計をテキスト返信。LIFF SPA でドーナツグラフ・ドリルダウン・月ナビゲーションを提供
 
 ## 使い方
 
@@ -56,15 +57,39 @@ curl -X POST https://{cloud-run-url}/card/import
 - 重複キー: 利用日 + 利用店名 + 利用者 + 利用金額
 - 処理結果は logs シートに記録（処理名: `card trans`）
 
+### ④ 月別集計
+
+LINE グループで「集計」と投稿するとカテゴリ別支出と入金合計をテキストで返信します。
+
+```
+📊 2026年4月の集計
+
+【支出カテゴリ別】
+食費　¥45,230
+日用品　¥12,800
+交通費　¥8,500
+──────────────
+支出合計　¥67,760
+
+【入金】
+入金合計　¥350,000
+```
+
+`LIFF_URL` を設定すると「📊 グラフで見る」ボタンも返信します。ボタンから開く SPA では前月・翌月ナビゲーション、カテゴリ別ドーナツグラフ、タップで明細ドリルダウンが利用できます。
+
+- 各シートの「除外」列（receipts: L列 / bank trans: I列 / card trans: K列）にテキストがある行は集計から除外
+- bank trans の区分「入金」は支出と分離して入金合計に計上
+
 ## システム構成
 
 ```
 LINE Bot
-  ↓ (webhook)
+  ↓ (webhook / text)
 ├─ Cloud Run (Express)
-   ├─ Gemini 2.5 Flash (レシート解析)
-   ├─ Google Sheets API (記録)
-   └─ Google Drive API (CSV 取得)
+   ├─ Gemini 2.5 Flash (レシート解析・カテゴリ判定)
+   ├─ Google Sheets API (記録・集計)
+   ├─ Google Drive API (CSV 取得)
+   └─ public/summary.html (LIFF SPA)
 ```
 
 **無料枠:**
@@ -77,10 +102,11 @@ LINE Bot
 
 ```
 src/
-├── index.js                   # Express サーバー + Webhook / bank/import / card/import エンドポイント
-├── lineHandler.js             # LINE イベント処理（画像受信・ユーザー取得）
+├── index.js                   # Express サーバー + 全エンドポイント + 静的ファイル配信
+├── lineHandler.js             # LINE イベント処理（画像受信・テキスト「集計」対応）
 ├── geminiParser.js            # Gemini でレシート画像を構造化データに変換
 ├── sheetsLogger.js            # receipts シートに記録
+├── aggregationService.js      # 月別集計（receipts / bank trans / card trans）
 ├── bankTransactionImporter.js # 銀行取引インポート処理のオーケストレーション
 ├── bankCsvParser.js           # 銀行 CSV パース（Shift-JIS 対応・半角カナ全角変換）
 ├── bankTransactionDedup.js    # 銀行取引の重複チェック
@@ -90,6 +116,9 @@ src/
 ├── cardTransactionDedup.js    # カード取引の重複チェック
 ├── categoryService.js         # カテゴリ自動判定（ルール照合 + Gemini バッチ）
 └── logger.js                  # logs シートへの処理結果記録
+
+public/
+└── summary.html               # 月別集計 SPA（LIFF・Chart.js CDN）
 
 conf/
 ├── bank_mapping/              # 銀行ごとのマッピング設定
@@ -116,6 +145,7 @@ Dockerfile           # Cloud Run デプロイ用
 3. `gcloud run deploy --source .` でデプロイ
 4. Webhook URL を LINE に設定
 5. ボットをグループに追加
+6. （任意）LINE Login チャンネルを作成し LIFF アプリを登録 → `LIFF_URL` を環境変数に設定
 
 ## 技術スタック
 
@@ -143,6 +173,8 @@ Dockerfile           # Cloud Run デプロイ用
 | H | 支払い方法 |
 | I | 品目 |
 | J | 備考 |
+| K | カテゴリ（自動）|
+| L | 除外（集計から除く場合に記入）|
 
 ### card trans シート（カード利用明細）
 
@@ -157,6 +189,8 @@ Dockerfile           # Cloud Run デプロイ用
 | G | 支払総額 |
 | H | 支払月 |
 | I | カード名 |
+| J | カテゴリ（自動）|
+| K | 除外（集計から除く場合に記入）|
 
 ### bank trans シート（銀行取引）
 
@@ -170,6 +204,7 @@ Dockerfile           # Cloud Run デプロイ用
 | F | コメント |
 | G | カテゴリ（自動）|
 | H | 銀行名 |
+| I | 除外（集計から除く場合に記入）|
 
 ### logs シート（インポート処理ログ）
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,7 +7,76 @@
 | POST | `/webhook` | LINE Messaging API からのイベント受信 |
 | POST | `/bank/import` | 銀行取引 CSV インポート |
 | POST | `/card/import` | カード利用明細 CSV インポート |
+| GET | `/summary` | 月別集計 JSON |
+| GET | `/summary.html` | 月別集計 SPA |
 | GET | `/health` | ヘルスチェック |
+
+---
+
+## GET /summary
+
+指定月のカテゴリ別集計データを返します。SPA および LINE Bot の集計返信で使用します。
+
+**リクエスト:**
+
+```
+GET https://{cloud-run-url}/summary?month=2026-04
+```
+
+**レスポンス（成功）:**
+
+```json
+{
+  "month": "2026-04",
+  "expenseTotal": 67760,
+  "incomeTotal": 350000,
+  "categories": {
+    "食費": {
+      "total": 45230,
+      "transactions": [
+        { "date": "2026/04/10", "label": "セブンイレブン", "amount": 1280, "source": "receipt", "detail": "田中太郎" },
+        { "date": "2026/04/12", "label": "マルエツ", "amount": 3240, "source": "card", "detail": "楽天カード" }
+      ]
+    },
+    "交通費": {
+      "total": 8500,
+      "transactions": [...]
+    }
+  },
+  "income": {
+    "total": 350000,
+    "transactions": [
+      { "date": "2026/04/25", "label": "給与", "amount": 350000, "source": "bank", "detail": "共通口座（埼玉りそな）" }
+    ]
+  }
+}
+```
+
+**`source` の値:**
+
+| 値 | 意味 |
+|----|------|
+| `receipt` | receipts シート（レシート画像） |
+| `bank` | bank trans シート（銀行取引） |
+| `card` | card trans シート（カード利用） |
+
+**除外ルール:**
+- 各シートの「除外」列にテキストがある行はスキップ（receipts: L列 / bank trans: I列 / card trans: K列）
+- bank trans の区分（C列）が「入金」の行は `categories` ではなく `income` に分類
+
+**エラー:**
+
+```json
+{ "error": "month パラメータが必要です（例: 2026-04）" }
+```
+
+---
+
+## GET /summary.html
+
+月別集計 SPA を返します。`?month=YYYY-MM` クエリパラメータで表示月を指定できます（省略時は先月）。
+
+LIFF アプリのエンドポイント URL として登録します。
 
 ---
 
@@ -307,6 +376,7 @@ Content-Type: application/json
 | I | String | 品目（改行区切り）| `おにぎり 150円\nコーヒー 180円` |
 | J | String | 備考 | `支払い日時はレシートから読み取れなかったため受信日時を使用` |
 | K | String | カテゴリ（自動）| `食費` |
+| L | String | 除外 | `除外`（集計から除く場合に任意のテキストを記入）|
 
 ### bank trans シート（銀行取引）
 
@@ -322,6 +392,7 @@ Content-Type: application/json
 | F | String | コメント | `` |
 | G | String | カテゴリ（自動）| `` |
 | H | String | 銀行名 | `共通口座（埼玉りそな）` |
+| I | String | 除外 | `除外`（集計から除く場合に任意のテキストを記入）|
 
 ### card trans シート（カード利用明細）
 
@@ -339,6 +410,7 @@ Content-Type: application/json
 | H | String | 支払月 | `5月` |
 | I | String | カード名 | `楽天カード` |
 | J | String | カテゴリ（自動）| `食費` |
+| K | String | 除外 | `除外`（集計から除く場合に任意のテキストを記入）|
 
 ### category rules シート（カテゴリルール）
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,6 +24,7 @@
         │  │  - /webhook      (POST)      │   │
         │  │  - /bank/import  (POST)      │   │
         │  │  - /card/import  (POST)      │   │
+        │  │  - /summary      (GET)       │   │
         │  │  - /health       (GET)       │   │
         │  └────────┬──────────┬──────────┘   │
         │           │          │              │
@@ -52,6 +53,8 @@
 - `POST /webhook` — LINE のイベント受信（middleware で署名検証）
 - `POST /bank/import` — 銀行取引 CSV インポート
 - `POST /card/import` — カード利用明細 CSV インポート
+- `GET /summary?month=YYYY-MM` — 月別集計 JSON
+- `GET /summary.html` — 月別集計 SPA（静的ファイル配信）
 - `GET /health` — ヘルスチェック
 
 **環境変数:**
@@ -65,6 +68,7 @@ BANK_TRANS_SHEET_NAME        # 銀行取引シート名（default: bank trans）
 CARD_TRANS_SHEET_NAME        # カード取引シート名（default: card trans）
 LOGS_SHEET_NAME              # ログシート名（default: logs）
 CATEGORY_RULES_SHEET_NAME    # カテゴリルールシート名（default: category rules）
+LIFF_URL                     # LIFF アプリの URL（設定時は集計返信にボタンを追加）
 BANK_FOLDER_ID               # 銀行 CSV を置く Google Drive フォルダ ID
 CARD_FOLDER_ID               # カード CSV を置く Google Drive フォルダ ID
 GOOGLE_SERVICE_ACCOUNT_JSON  # GCP サービスアカウント認証情報
@@ -80,7 +84,11 @@ GOOGLE_SERVICE_ACCOUNT_JSON  # GCP サービスアカウント認証情報
 Event 受信
   ↓
 [メッセージタイプ判定]
-  ├─ 画像以外 → 無視して終了
+  ├─ テキストメッセージ（「集計」を含む）
+  │   └─ aggregationService で先月集計
+  │       → テキスト返信 + LIFF ボタン（LIFF_URL 設定時）
+  │
+  ├─ 画像以外（テキストで「集計」を含まない等）→ 無視して終了
   │
   └─ 画像メッセージ
       ↓
@@ -145,7 +153,55 @@ Event 受信
 
 ---
 
-### 5. カテゴリサービス (`src/categoryService.js`)
+### 5. 集計サービス (`src/aggregationService.js`)
+
+**役割:** receipts / bank trans / card trans の 3 シートから月別集計データを構築
+
+**フロー:**
+
+```
+[3 シートを並行読み込み]
+  ↓
+[各行をフィルタリング]
+  ├─ 対象月の行のみ抽出（日付列で判定）
+  └─ 除外列にテキストがある行をスキップ
+      receipts: L列 / bank trans: I列 / card trans: K列
+  ↓
+[集計]
+  ├─ receipts: カテゴリ（K列）別に金額（G列）を合算
+  ├─ bank trans:
+  │   ├─ 区分（C列）=「入金」→ 入金合計に計上
+  │   └─ それ以外 → カテゴリ（G列）別に金額（B列）を合算
+  └─ card trans: カテゴリ（J列）別に金額（E列）を合算
+  ↓
+[明細を日付昇順でソート]
+```
+
+**レスポンス形式:**
+```json
+{
+  "month": "2026-04",
+  "expenseTotal": 86530,
+  "incomeTotal": 350000,
+  "categories": {
+    "食費": {
+      "total": 45230,
+      "transactions": [
+        { "date": "2026/04/10", "label": "セブンイレブン", "amount": 1280,
+          "source": "receipt", "detail": "田中太郎" }
+      ]
+    }
+  },
+  "income": {
+    "total": 350000,
+    "transactions": [...]
+  }
+}
+```
+
+---
+
+### 6. カテゴリサービス (`src/categoryService.js`)
 
 **役割:** レシート・銀行・カードの全トランザクションにカテゴリを自動付与
 
@@ -175,7 +231,7 @@ Event 受信
 
 ---
 
-### 6. 銀行取引インポート・カード利用明細インポート
+### 7. 銀行取引インポート・カード利用明細インポート
 
 #### 銀行取引フロー（`POST /bank/import`）
 

--- a/docs/QUICKREF.md
+++ b/docs/QUICKREF.md
@@ -49,6 +49,12 @@ receipt-log/
 │   │       照合キー: 利用日 + 利用店名 + 利用者 + 利用金額
 │   │       ※ファイル内重複はすべて取り込み、Sheets 既存データのみスキップ
 │   │
+│   ├── aggregationService.js
+│   │   └─ 月別集計（receipts / bank trans / card trans）
+│   │       - 除外列にテキストがある行をスキップ
+│   │       - bank trans の「入金」区分を支出から分離
+│   │       - getLastMonth() で先月を YYYY-MM 形式で返す
+│   │
 │   ├── categoryService.js
 │   │   └─ カテゴリ自動判定（ルール照合 + Gemini バッチ）
 │   │       ① category rules シートからキーワードを読み込み部分一致で判定
@@ -58,6 +64,12 @@ receipt-log/
 │   └── logger.js
 │       └─ logs シートへの処理結果記録
 │           範囲: {LOGS_SHEET_NAME}!A:I
+│
+├── public/
+│   └── summary.html             # 月別集計 SPA（Chart.js CDN、ビルド不要）
+│       - 前月・翌月ナビゲーション（?month= クエリで制御）
+│       - カテゴリ別ドーナツグラフ
+│       - ボトムシートでドリルダウン（スワイプで閉じる）
 │
 ├── conf/
 │   ├── bank_mapping/
@@ -99,6 +111,7 @@ receipt-log/
 | `CARD_FOLDER_ID` | カード CSV フォルダ ID | Drive の URL: `/folders/{ID}` |
 | `CARD_TRANS_SHEET_NAME` | カード取引シート名（default: card trans）| Google Sheets タブ名 |
 | `CATEGORY_RULES_SHEET_NAME` | カテゴリルールシート名（default: category rules）| Google Sheets タブ名 |
+| `LIFF_URL` | LIFF アプリの URL（任意）| LINE Developers > LINE Login チャンネル > LIFF |
 | `GOOGLE_SERVICE_ACCOUNT_JSON` | GCP サービスアカウント認証 | gcloud iam service-accounts keys create |
 
 ---
@@ -202,6 +215,16 @@ curl -X POST http://localhost:8080/card/import \
   -d '{"spreadsheetId": "...", "cardFolderId": "..."}'
 ```
 
+### 月別集計のローカルテスト
+
+```bash
+# JSON API
+curl "http://localhost:8080/summary?month=2026-04"
+
+# SPA をブラウザで確認
+open "http://localhost:8080/summary.html?month=2026-04"
+```
+
 ---
 
 ## エラー対応フローチャート
@@ -290,6 +313,16 @@ POST /card/import
 - [ ] category rules シートのルールが照合される（部分一致）
 - [ ] 未知の店名は Gemini で判定される
 - [ ] 新規ルールが category rules シートに自動追記される
+
+### 月別集計機能
+- [ ] `GET /summary?month=YYYY-MM` が正しい JSON を返すこと
+- [ ] SPA でグラフ・カテゴリリスト・入金が表示されること
+- [ ] 前月・翌月ナビゲーションが機能すること
+- [ ] カテゴリ・入金タップでドリルダウン明細が開くこと
+- [ ] 明細が日付昇順で表示されること
+- [ ] 除外列にテキストがある行が集計に含まれないこと
+- [ ] LINE で「集計」と送信するとテキスト集計が返ること
+- [ ] LIFF_URL 設定時に「グラフで見る」ボタンが返ること
 
 ---
 

--- a/public/summary.html
+++ b/public/summary.html
@@ -1,0 +1,602 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <title>月別集計</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #f4f6f9;
+      --surface: #ffffff;
+      --primary: #4A90D9;
+      --income-color: #27ae60;
+      --text: #2c3e50;
+      --text-muted: #7f8c8d;
+      --border: #e8ecef;
+      --radius: 12px;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+    }
+
+    /* ── ヘッダー ── */
+    header {
+      background: var(--primary);
+      color: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 14px 16px;
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      box-shadow: 0 2px 8px rgba(0,0,0,.15);
+    }
+    .nav-btn {
+      background: rgba(255,255,255,.2);
+      border: none;
+      color: #fff;
+      font-size: 18px;
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background .15s;
+    }
+    .nav-btn:active { background: rgba(255,255,255,.35); }
+    #month-title { font-size: 18px; font-weight: 700; }
+
+    /* ── メインコンテンツ ── */
+    main { padding: 16px; max-width: 480px; margin: 0 auto; }
+
+    /* ── サマリーカード ── */
+    .summary-cards {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .card {
+      background: var(--surface);
+      border-radius: var(--radius);
+      padding: 16px;
+      text-align: center;
+      box-shadow: 0 1px 4px rgba(0,0,0,.06);
+    }
+    .card-label {
+      font-size: 11px;
+      color: var(--text-muted);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .5px;
+      margin-bottom: 6px;
+    }
+    .card-amount {
+      font-size: 20px;
+      font-weight: 700;
+      color: var(--text);
+    }
+    .card.income .card-amount { color: var(--income-color); }
+
+    /* ── グラフセクション ── */
+    .chart-section {
+      background: var(--surface);
+      border-radius: var(--radius);
+      padding: 16px;
+      margin-bottom: 16px;
+      box-shadow: 0 1px 4px rgba(0,0,0,.06);
+    }
+    .section-title {
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--text-muted);
+      margin-bottom: 12px;
+      text-transform: uppercase;
+      letter-spacing: .5px;
+    }
+    .chart-wrapper {
+      position: relative;
+      width: 200px;
+      height: 200px;
+      margin: 0 auto 8px;
+    }
+    .chart-center-label {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      pointer-events: none;
+    }
+    .chart-center-label .center-sub { font-size: 11px; color: var(--text-muted); }
+    .chart-center-label .center-val { font-size: 17px; font-weight: 700; }
+
+    /* ── カテゴリリスト ── */
+    .list-section {
+      background: var(--surface);
+      border-radius: var(--radius);
+      overflow: hidden;
+      margin-bottom: 16px;
+      box-shadow: 0 1px 4px rgba(0,0,0,.06);
+    }
+    .list-section-title {
+      padding: 14px 16px 10px;
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: .5px;
+      border-bottom: 1px solid var(--border);
+    }
+    .category-row {
+      display: flex;
+      align-items: center;
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--border);
+      cursor: pointer;
+      transition: background .1s;
+      gap: 12px;
+    }
+    .category-row:last-child { border-bottom: none; }
+    .category-row:active { background: #f8f9fa; }
+    .dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .cat-info { flex: 1; min-width: 0; }
+    .cat-name {
+      font-size: 15px;
+      font-weight: 600;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .cat-count { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
+    .cat-right { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+    .cat-amount { font-size: 15px; font-weight: 700; }
+    .chevron { color: var(--text-muted); font-size: 14px; }
+
+    /* ── 入金行 ── */
+    .income-row .cat-amount { color: var(--income-color); }
+
+    /* ── ドリルダウンシート ── */
+    .sheet-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,.4);
+      z-index: 100;
+    }
+    .sheet-overlay.open { display: block; }
+    .sheet {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: var(--surface);
+      border-radius: 20px 20px 0 0;
+      max-height: 75vh;
+      display: flex;
+      flex-direction: column;
+      transform: translateY(100%);
+      transition: transform .28s cubic-bezier(.32,1,.32,1);
+      z-index: 101;
+    }
+    .sheet.open { transform: translateY(0); }
+    .sheet-handle {
+      width: 36px;
+      height: 4px;
+      background: var(--border);
+      border-radius: 2px;
+      margin: 12px auto 0;
+      flex-shrink: 0;
+    }
+    .sheet-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 16px 10px;
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .sheet-header-left { display: flex; align-items: center; gap: 10px; }
+    .sheet-title { font-size: 16px; font-weight: 700; }
+    .sheet-total { font-size: 14px; color: var(--text-muted); }
+    .close-btn {
+      background: none;
+      border: none;
+      font-size: 20px;
+      color: var(--text-muted);
+      cursor: pointer;
+      padding: 4px;
+      line-height: 1;
+    }
+    .sheet-body { overflow-y: auto; flex: 1; padding-bottom: 16px; }
+
+    /* ── 明細行 ── */
+    .tx-row {
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border);
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 4px 12px;
+      align-items: start;
+    }
+    .tx-row:last-child { border-bottom: none; }
+    .tx-label {
+      font-size: 14px;
+      font-weight: 500;
+      grid-column: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .tx-amount {
+      font-size: 14px;
+      font-weight: 700;
+      grid-column: 2;
+      grid-row: 1 / 3;
+      align-self: center;
+      white-space: nowrap;
+    }
+    .tx-meta {
+      grid-column: 1;
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+    .tx-date { font-size: 12px; color: var(--text-muted); }
+    .badge {
+      font-size: 10px;
+      font-weight: 600;
+      padding: 1px 6px;
+      border-radius: 10px;
+    }
+    .badge-receipt { background: #fff3cd; color: #856404; }
+    .badge-bank    { background: #d1ecf1; color: #0c5460; }
+    .badge-card    { background: #e2d9f3; color: #5a1a8a; }
+    .tx-detail { font-size: 12px; color: var(--text-muted); }
+
+    /* ── ローディング / エラー ── */
+    .state-msg {
+      text-align: center;
+      padding: 48px 16px;
+      color: var(--text-muted);
+      font-size: 15px;
+    }
+    .spinner {
+      width: 36px;
+      height: 36px;
+      border: 3px solid var(--border);
+      border-top-color: var(--primary);
+      border-radius: 50%;
+      animation: spin .7s linear infinite;
+      margin: 0 auto 12px;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ── 空状態 ── */
+    .empty { text-align: center; padding: 32px 16px; color: var(--text-muted); }
+  </style>
+</head>
+<body>
+
+<header>
+  <button class="nav-btn" id="prev-btn" title="前月">&#8249;</button>
+  <span id="month-title">読み込み中…</span>
+  <button class="nav-btn" id="next-btn" title="翌月">&#8250;</button>
+</header>
+
+<main id="main">
+  <div class="state-msg"><div class="spinner"></div>読み込み中…</div>
+</main>
+
+<!-- ドリルダウンシート -->
+<div class="sheet-overlay" id="overlay"></div>
+<div class="sheet" id="sheet">
+  <div class="sheet-handle"></div>
+  <div class="sheet-header">
+    <div class="sheet-header-left">
+      <span class="dot" id="sheet-dot" style="width:14px;height:14px;"></span>
+      <span class="sheet-title" id="sheet-title"></span>
+    </div>
+    <div style="display:flex;align-items:center;gap:12px;">
+      <span class="sheet-total" id="sheet-total"></span>
+      <button class="close-btn" id="close-btn">&#x2715;</button>
+    </div>
+  </div>
+  <div class="sheet-body" id="sheet-body"></div>
+</div>
+
+<script>
+const PALETTE = [
+  "#4A90D9","#E8734A","#27AE60","#F1C40F","#9B59B6",
+  "#1ABC9C","#E74C3C","#3498DB","#F39C12","#2ECC71",
+  "#8E44AD","#16A085"
+];
+const SOURCE_LABELS = { receipt: "レシート", bank: "銀行", card: "カード" };
+const BADGE_CLASSES = { receipt: "badge-receipt", bank: "badge-bank", card: "badge-card" };
+
+let currentMonth = getMonthFromUrl();
+let chartInstance = null;
+let currentData = null;
+
+function getMonthFromUrl() {
+  const p = new URLSearchParams(location.search);
+  const m = p.get("month");
+  if (m && /^\d{4}-\d{2}$/.test(m)) return m;
+  // デフォルト: 先月
+  const now = new Date();
+  const y = now.getMonth() === 0 ? now.getFullYear() - 1 : now.getFullYear();
+  const mo = now.getMonth() === 0 ? 12 : now.getMonth();
+  return `${y}-${String(mo).padStart(2, "0")}`;
+}
+
+function setMonthInUrl(month) {
+  const u = new URL(location.href);
+  u.searchParams.set("month", month);
+  history.replaceState(null, "", u.toString());
+}
+
+function offsetMonth(month, delta) {
+  const [y, m] = month.split("-").map(Number);
+  const d = new Date(y, m - 1 + delta, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function formatMonth(month) {
+  const [y, m] = month.split("-");
+  return `${y}年${parseInt(m)}月`;
+}
+
+function fmt(n) {
+  return "¥" + Math.round(n).toLocaleString();
+}
+
+async function loadData(month) {
+  setMonthInUrl(month);
+  document.getElementById("month-title").textContent = formatMonth(month);
+  document.getElementById("main").innerHTML =
+    '<div class="state-msg"><div class="spinner"></div>読み込み中…</div>';
+
+  if (chartInstance) { chartInstance.destroy(); chartInstance = null; }
+
+  let data;
+  try {
+    const res = await fetch(`/summary?month=${month}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    data = await res.json();
+  } catch (e) {
+    document.getElementById("main").innerHTML =
+      `<div class="state-msg">データの取得に失敗しました。<br><small>${e.message}</small></div>`;
+    return;
+  }
+
+  currentData = data;
+  render(data);
+}
+
+function render(data) {
+  const main = document.getElementById("main");
+
+  const sortedCats = Object.entries(data.categories).sort(([,a],[,b]) => b.total - a.total);
+  const hasExpense = sortedCats.length > 0;
+  const hasIncome = data.incomeTotal > 0;
+
+  if (!hasExpense && !hasIncome) {
+    main.innerHTML = '<div class="empty">この月のデータはありません</div>';
+    return;
+  }
+
+  // カラーマップ（カテゴリ名 → 色）
+  const colorMap = {};
+  sortedCats.forEach(([name], i) => {
+    colorMap[name] = PALETTE[i % PALETTE.length];
+  });
+
+  let html = "";
+
+  // ── サマリーカード ──
+  html += `
+    <div class="summary-cards">
+      <div class="card">
+        <div class="card-label">支出合計</div>
+        <div class="card-amount">${fmt(data.expenseTotal)}</div>
+      </div>
+      <div class="card income">
+        <div class="card-label">入金合計</div>
+        <div class="card-amount">${fmt(data.incomeTotal)}</div>
+      </div>
+    </div>`;
+
+  // ── ドーナツグラフ ──
+  if (hasExpense) {
+    html += `
+      <div class="chart-section">
+        <div class="section-title">支出内訳</div>
+        <div class="chart-wrapper">
+          <canvas id="donut"></canvas>
+          <div class="chart-center-label">
+            <div class="center-sub">支出合計</div>
+            <div class="center-val">${fmt(data.expenseTotal)}</div>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  // ── カテゴリリスト ──
+  if (hasExpense) {
+    html += `<div class="list-section"><div class="list-section-title">支出カテゴリ</div>`;
+    for (const [name, cat] of sortedCats) {
+      const color = colorMap[name];
+      const pct = data.expenseTotal > 0
+        ? Math.round(cat.total / data.expenseTotal * 100) : 0;
+      html += `
+        <div class="category-row" data-cat="${escHtml(name)}">
+          <span class="dot" style="background:${color}"></span>
+          <div class="cat-info">
+            <div class="cat-name">${escHtml(name)}</div>
+            <div class="cat-count">${cat.transactions.length}件 ・ ${pct}%</div>
+          </div>
+          <div class="cat-right">
+            <span class="cat-amount">${fmt(cat.total)}</span>
+            <span class="chevron">›</span>
+          </div>
+        </div>`;
+    }
+    html += `</div>`;
+  }
+
+  // ── 入金 ──
+  if (hasIncome) {
+    html += `
+      <div class="list-section">
+        <div class="list-section-title">入金</div>
+        <div class="category-row income-row" data-cat="__income__">
+          <span class="dot" style="background:${PALETTE[11]}"></span>
+          <div class="cat-info">
+            <div class="cat-name">入金</div>
+            <div class="cat-count">${data.income.transactions.length}件</div>
+          </div>
+          <div class="cat-right">
+            <span class="cat-amount" style="color:var(--income-color)">${fmt(data.incomeTotal)}</span>
+            <span class="chevron">›</span>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  main.innerHTML = html;
+
+  // グラフ描画
+  if (hasExpense) {
+    const ctx = document.getElementById("donut").getContext("2d");
+    chartInstance = new Chart(ctx, {
+      type: "doughnut",
+      data: {
+        labels: sortedCats.map(([n]) => n),
+        datasets: [{
+          data: sortedCats.map(([, c]) => c.total),
+          backgroundColor: sortedCats.map(([n]) => colorMap[n]),
+          borderWidth: 2,
+          borderColor: "#fff",
+          hoverOffset: 4,
+        }],
+      },
+      options: {
+        cutout: "62%",
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label: (ctx) => ` ${ctx.label}: ${fmt(ctx.raw)}`,
+            },
+          },
+        },
+        onClick: (e, els) => {
+          if (els.length) {
+            const name = sortedCats[els[0].index][0];
+            openSheet(name, colorMap[name], currentData);
+          }
+        },
+      },
+    });
+  }
+
+  // カテゴリ行クリック
+  main.querySelectorAll(".category-row").forEach(row => {
+    row.addEventListener("click", () => {
+      const cat = row.dataset.cat;
+      const color = cat === "__income__"
+        ? PALETTE[11]
+        : (colorMap[cat] || "#ccc");
+      openSheet(cat, color, currentData);
+    });
+  });
+}
+
+function openSheet(catKey, color, data) {
+  const isIncome = catKey === "__income__";
+  const transactions = isIncome
+    ? data.income.transactions
+    : (data.categories[catKey]?.transactions || []);
+  const total = isIncome ? data.incomeTotal : (data.categories[catKey]?.total || 0);
+
+  document.getElementById("sheet-dot").style.background = color;
+  document.getElementById("sheet-title").textContent = isIncome ? "入金" : catKey;
+  document.getElementById("sheet-total").textContent = fmt(total);
+
+  const body = document.getElementById("sheet-body");
+  if (transactions.length === 0) {
+    body.innerHTML = '<div class="empty">明細なし</div>';
+  } else {
+    body.innerHTML = transactions.map(tx => `
+      <div class="tx-row">
+        <div class="tx-label">${escHtml(tx.label || "（不明）")}</div>
+        <div class="tx-amount">${isIncome ? "+" : ""}${fmt(tx.amount)}</div>
+        <div class="tx-meta">
+          <span class="tx-date">${escHtml(tx.date)}</span>
+          <span class="badge ${BADGE_CLASSES[tx.source] || ""}">${SOURCE_LABELS[tx.source] || tx.source}</span>
+          ${tx.detail ? `<span class="tx-detail">${escHtml(tx.detail)}</span>` : ""}
+        </div>
+      </div>
+    `).join("");
+  }
+
+  document.getElementById("overlay").classList.add("open");
+  document.getElementById("sheet").classList.add("open");
+  document.body.style.overflow = "hidden";
+}
+
+function closeSheet() {
+  document.getElementById("overlay").classList.remove("open");
+  document.getElementById("sheet").classList.remove("open");
+  document.body.style.overflow = "";
+}
+
+function escHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// ── イベントリスナー ──
+document.getElementById("prev-btn").addEventListener("click", () => {
+  currentMonth = offsetMonth(currentMonth, -1);
+  loadData(currentMonth);
+});
+document.getElementById("next-btn").addEventListener("click", () => {
+  currentMonth = offsetMonth(currentMonth, 1);
+  loadData(currentMonth);
+});
+document.getElementById("close-btn").addEventListener("click", closeSheet);
+document.getElementById("overlay").addEventListener("click", closeSheet);
+
+// スワイプで閉じる
+let touchStartY = 0;
+document.getElementById("sheet").addEventListener("touchstart", e => {
+  touchStartY = e.touches[0].clientY;
+}, { passive: true });
+document.getElementById("sheet").addEventListener("touchend", e => {
+  if (e.changedTouches[0].clientY - touchStartY > 60) closeSheet();
+}, { passive: true });
+
+// 初回ロード
+loadData(currentMonth);
+</script>
+</body>
+</html>

--- a/src/aggregationService.js
+++ b/src/aggregationService.js
@@ -96,11 +96,11 @@ async function aggregateByMonth(spreadsheetId, month) {
     });
   }
 
-  // カテゴリ内をそれぞれ日付降順でソート
+  // カテゴリ内をそれぞれ日付昇順でソート
   for (const cat of Object.values(categories)) {
-    cat.transactions.sort((a, b) => (b.date > a.date ? 1 : -1));
+    cat.transactions.sort((a, b) => (a.date > b.date ? 1 : -1));
   }
-  income.transactions.sort((a, b) => (b.date > a.date ? 1 : -1));
+  income.transactions.sort((a, b) => (a.date > b.date ? 1 : -1));
 
   const expenseTotal = Object.values(categories).reduce((s, c) => s + c.total, 0);
 

--- a/src/aggregationService.js
+++ b/src/aggregationService.js
@@ -1,0 +1,142 @@
+const { google } = require("googleapis");
+
+function getAuth() {
+  const credentials = JSON.parse(process.env.GOOGLE_SERVICE_ACCOUNT_JSON);
+  return new google.auth.GoogleAuth({
+    credentials,
+    scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+  });
+}
+
+/**
+ * 日付文字列から YYYY-MM を抽出
+ * 対応: "2026/04/10 15:32", "2026/04/10", "2026-04-10"
+ */
+function extractYearMonth(dateStr) {
+  if (!dateStr) return null;
+  const m = String(dateStr).match(/(\d{4})[\/\-](\d{2})/);
+  return m ? `${m[1]}-${m[2]}` : null;
+}
+
+/**
+ * 指定月の集計データを返す
+ * @param {string} spreadsheetId
+ * @param {string} month - "YYYY-MM"
+ * @returns {Promise<{month, expenseTotal, incomeTotal, categories, income}>}
+ */
+async function aggregateByMonth(spreadsheetId, month) {
+  const auth = getAuth();
+  const sheets = google.sheets({ version: "v4", auth });
+
+  const [receiptsRows, bankRows, cardRows] = await Promise.all([
+    getSheetRows(sheets, spreadsheetId, process.env.SHEET_NAME || "receipts", "A:L"),
+    getSheetRows(sheets, spreadsheetId, process.env.BANK_TRANS_SHEET_NAME || "bank trans", "A:I"),
+    getSheetRows(sheets, spreadsheetId, process.env.CARD_TRANS_SHEET_NAME || "card trans", "A:K"),
+  ]);
+
+  const categories = {};
+  const income = { total: 0, transactions: [] };
+
+  // receipts: B=支払い日時, F=店名, G=金額, K=カテゴリ, L=除外
+  for (const row of receiptsRows) {
+    if (extractYearMonth(row[1]) !== month) continue;
+    if (row[11]) continue; // L列: 除外
+    const amount = parseFloat(row[6]) || 0;
+    if (!amount) continue;
+    const category = row[10] || "その他"; // K列
+    addTransaction(categories, category, {
+      date: String(row[1] || "").split(" ")[0],
+      label: row[5] || "",   // F列: 店名
+      amount,
+      source: "receipt",
+      detail: row[3] || "",  // D列: 表示名
+    });
+  }
+
+  // bank trans: A=取引日, B=金額, C=区分, E=摘要, G=カテゴリ, H=銀行名, I=除外
+  for (const row of bankRows) {
+    if (extractYearMonth(row[0]) !== month) continue;
+    if (row[8]) continue; // I列: 除外
+    const amount = parseFloat(row[1]) || 0;
+    if (!amount) continue;
+    if (row[2] === "入金") {
+      income.total += amount;
+      income.transactions.push({
+        date: row[0] || "",
+        label: row[4] || "",  // E列: 摘要
+        amount,
+        source: "bank",
+        detail: row[7] || "", // H列: 銀行名
+      });
+    } else {
+      const category = row[6] || "その他"; // G列
+      addTransaction(categories, category, {
+        date: row[0] || "",
+        label: row[4] || "",  // E列: 摘要
+        amount: Math.abs(amount),
+        source: "bank",
+        detail: row[7] || "", // H列: 銀行名
+      });
+    }
+  }
+
+  // card trans: A=利用日, B=利用店名, E=利用金額, I=カード名, J=カテゴリ, K=除外
+  for (const row of cardRows) {
+    if (extractYearMonth(row[0]) !== month) continue;
+    if (row[10]) continue; // K列: 除外
+    const amount = parseFloat(row[4]) || 0; // E列
+    if (!amount) continue;
+    const category = row[9] || "その他"; // J列
+    addTransaction(categories, category, {
+      date: row[0] || "",
+      label: row[1] || "",  // B列: 利用店名
+      amount,
+      source: "card",
+      detail: row[8] || "", // I列: カード名
+    });
+  }
+
+  // カテゴリ内をそれぞれ日付降順でソート
+  for (const cat of Object.values(categories)) {
+    cat.transactions.sort((a, b) => (b.date > a.date ? 1 : -1));
+  }
+  income.transactions.sort((a, b) => (b.date > a.date ? 1 : -1));
+
+  const expenseTotal = Object.values(categories).reduce((s, c) => s + c.total, 0);
+
+  return { month, expenseTotal, incomeTotal: income.total, categories, income };
+}
+
+function addTransaction(categories, category, tx) {
+  if (!categories[category]) {
+    categories[category] = { total: 0, transactions: [] };
+  }
+  categories[category].total += tx.amount;
+  categories[category].transactions.push(tx);
+}
+
+async function getSheetRows(sheets, spreadsheetId, sheetName, range) {
+  try {
+    const res = await sheets.spreadsheets.values.get({
+      spreadsheetId,
+      range: `${sheetName}!${range}`,
+    });
+    const rows = res.data.values || [];
+    return rows.slice(1); // ヘッダー行を除く
+  } catch (err) {
+    console.warn(`シート読み込み失敗 (${sheetName}):`, err.message);
+    return [];
+  }
+}
+
+/**
+ * 先月を YYYY-MM 形式で返す
+ */
+function getLastMonth() {
+  const now = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+  const year = now.getMonth() === 0 ? now.getFullYear() - 1 : now.getFullYear();
+  const month = now.getMonth() === 0 ? 12 : now.getMonth();
+  return `${year}-${String(month).padStart(2, "0")}`;
+}
+
+module.exports = { aggregateByMonth, getLastMonth };

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 require('dotenv').config({ path: process.env.DOTENV_PATH || '.env.local' });
 
+const path = require("path");
 const express = require("express");
 const { middleware, Client } = require("@line/bot-sdk");
 const { handleEvent } = require("./lineHandler");
 const { importBankTransactions } = require("./bankTransactionImporter");
 const { importCardTransactions } = require("./cardTransactionImporter");
+const { aggregateByMonth } = require("./aggregationService");
 
 const config = {
   channelSecret: process.env.LINE_CHANNEL_SECRET,
@@ -12,6 +14,9 @@ const config = {
 };
 
 const app = express();
+
+// 静的ファイル配信（SPA）
+app.use(express.static(path.join(__dirname, "..", "public")));
 
 app.post("/webhook", middleware(config), (req, res) => {
   // すぐにレスポンスを返す（LINE のタイムアウト防止）
@@ -23,6 +28,28 @@ app.post("/webhook", middleware(config), (req, res) => {
       console.error("イベント処理エラー:", err);
     });
   });
+});
+
+/**
+ * 月別集計 API
+ * GET /summary?month=YYYY-MM
+ */
+app.get("/summary", async (req, res) => {
+  const { month } = req.query;
+  if (!month || !/^\d{4}-\d{2}$/.test(month)) {
+    return res.status(400).json({ error: "month パラメータが必要です（例: 2026-04）" });
+  }
+  const spreadsheetId = process.env.SPREADSHEET_ID;
+  if (!spreadsheetId) {
+    return res.status(500).json({ error: "SPREADSHEET_ID が設定されていません" });
+  }
+  try {
+    const data = await aggregateByMonth(spreadsheetId, month);
+    res.json(data);
+  } catch (err) {
+    console.error("/summary エラー:", err);
+    res.status(500).json({ error: err.message });
+  }
 });
 
 /**

--- a/src/lineHandler.js
+++ b/src/lineHandler.js
@@ -23,7 +23,7 @@ async function handleEvent(event, client) {
  */
 async function handleTextMessage(event, client) {
   const text = event.message.text;
-  if (!text.includes("先月の集計")) return;
+  if (!text.includes("集計")) return;
 
   const replyToken = event.replyToken;
   const spreadsheetId = process.env.SPREADSHEET_ID;

--- a/src/lineHandler.js
+++ b/src/lineHandler.js
@@ -1,6 +1,7 @@
 const { parseReceipt } = require("./geminiParser");
 const { logToSheet } = require("./sheetsLogger");
 const { categorizeTransactions } = require("./categoryService");
+const { aggregateByMonth, getLastMonth } = require("./aggregationService");
 
 /**
  * LINE イベントを処理する
@@ -8,11 +9,97 @@ const { categorizeTransactions } = require("./categoryService");
  * @param {object} client - LINE Bot SDK クライアント
  */
 async function handleEvent(event, client) {
-  // 画像メッセージ以外は無視
-  if (event.type !== "message" || event.message.type !== "image") {
+  if (event.type !== "message") return;
+
+  if (event.message.type === "text") {
+    await handleTextMessage(event, client);
+  } else if (event.message.type === "image") {
+    await handleImageMessage(event, client);
+  }
+}
+
+/**
+ * テキストメッセージを処理する
+ */
+async function handleTextMessage(event, client) {
+  const text = event.message.text;
+  if (!text.includes("先月の集計")) return;
+
+  const replyToken = event.replyToken;
+  const spreadsheetId = process.env.SPREADSHEET_ID;
+  const month = getLastMonth();
+
+  let data;
+  try {
+    data = await aggregateByMonth(spreadsheetId, month);
+  } catch (err) {
+    console.error("集計失敗:", err);
+    await client.replyMessage(replyToken, {
+      type: "text",
+      text: "集計中にエラーが発生しました。",
+    });
     return;
   }
 
+  const [year, m] = month.split("-");
+  const title = `📊 ${year}年${parseInt(m)}月の集計`;
+
+  // カテゴリ別支出を金額降順で整形
+  const sortedCategories = Object.entries(data.categories).sort(
+    ([, a], [, b]) => b.total - a.total
+  );
+
+  let categoryLines = sortedCategories
+    .map(([name, c]) => `${name}　¥${c.total.toLocaleString()}`)
+    .join("\n");
+
+  if (!categoryLines) categoryLines = "（データなし）";
+
+  const summaryText =
+    `${title}\n\n` +
+    `【支出カテゴリ別】\n${categoryLines}\n` +
+    `──────────────\n` +
+    `支出合計　¥${data.expenseTotal.toLocaleString()}\n\n` +
+    `【入金】\n入金合計　¥${data.incomeTotal.toLocaleString()}`;
+
+  const messages = [{ type: "text", text: summaryText }];
+
+  const liffUrl = process.env.LIFF_URL;
+  if (liffUrl) {
+    messages.push({
+      type: "flex",
+      altText: "グラフで見る",
+      contents: {
+        type: "bubble",
+        size: "kilo",
+        body: {
+          type: "box",
+          layout: "vertical",
+          paddingAll: "md",
+          contents: [
+            {
+              type: "button",
+              action: {
+                type: "uri",
+                label: "📊 グラフで見る",
+                uri: `${liffUrl}?month=${month}`,
+              },
+              style: "primary",
+              color: "#4A90D9",
+            },
+          ],
+        },
+      },
+    });
+  }
+
+  await client.replyMessage(replyToken, messages);
+}
+
+/**
+ * 画像メッセージを処理する（レシート記録）
+ */
+async function handleImageMessage(event, client) {
   const userId = event.source.userId;
   const groupId = event.source.groupId ?? null;
   const replyToken = event.replyToken;


### PR DESCRIPTION
## Summary

- `aggregationService.js` を新規追加: receipts / bank trans / card trans の 3 シートから月別集計
  - 除外列（receipts:L / bank trans:I / card trans:K）のある行をスキップ
  - bank trans の区分「入金」は支出と分離して入金合計に計上
- `GET /summary?month=YYYY-MM` エンドポイントを追加
- `lineHandler.js`: 「集計」テキストメッセージでテキスト集計 + LIFF ボタンを返信
- `public/summary.html`: モバイルファースト SPA
  - 前月・翌月ナビゲーション
  - カテゴリ別ドーナツグラフ（Chart.js CDN）
  - カテゴリ・入金のボトムシートドリルダウン（明細を日付昇順表示）
  - スワイプでシートを閉じる
- `Dockerfile`: `public/` フォルダをコピーするよう追加
- LIFF は LINE Login チャンネルに作成し `LIFF_URL` 環境変数で設定

## Test plan

- [x] `GET /summary?month=YYYY-MM` が正しい集計 JSON を返すこと
- [x] SPA でグラフ・カテゴリリスト・入金が表示されること
- [x] 前月・翌月ナビゲーションが機能すること
- [x] カテゴリ・入金タップでドリルダウン明細が開くこと
- [x] 明細が日付昇順で表示されること
- [x] LINE で「集計」と送信するとテキスト集計 + ボタンが返ること
- [x] ボタンから SPA が開くこと

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)