### PR TITLE
feat: category rules の「除外」カテゴリで取引を自動除外

### DIFF
--- a/src/bankTransactionImporter.js
+++ b/src/bankTransactionImporter.js
@@ -178,7 +178,10 @@ async function processSingleFile(
       try {
         const descriptions = unique.map((t) => t.description);
         const categories = await categorizeTransactions(spreadsheetId, descriptions);
-        unique.forEach((t, i) => { t.categoryAuto = categories[i]; });
+        unique.forEach((t, i) => {
+          t.categoryAuto = categories[i];
+          if (t.categoryAuto === "除外") t.excludeAuto = "自動除外";
+        });
       } catch (err) {
         console.warn("銀行取引カテゴリ判定失敗:", err.message);
         unique.forEach((t) => { t.categoryAuto = "その他"; });
@@ -242,11 +245,12 @@ async function appendTransactionsToSheet(spreadsheetId, bankName, transactions) 
     t.comments,
     t.categoryAuto,
     bankName,
+    t.excludeAuto ?? "",
   ]);
 
   await sheets.spreadsheets.values.append({
     spreadsheetId,
-    range: `${sheetName}!A:H`,
+    range: `${sheetName}!A:I`,
     valueInputOption: "USER_ENTERED",
     insertDataOption: "INSERT_ROWS",
     requestBody: { values },

--- a/src/cardTransactionImporter.js
+++ b/src/cardTransactionImporter.js
@@ -140,7 +140,10 @@ async function processSingleFile(
       try {
         const descriptions = unique.map((t) => t.storeName);
         const categories = await categorizeTransactions(spreadsheetId, descriptions);
-        unique.forEach((t, i) => { t.categoryAuto = categories[i]; });
+        unique.forEach((t, i) => {
+          t.categoryAuto = categories[i];
+          if (t.categoryAuto === "除外") t.excludeAuto = "自動除外";
+        });
       } catch (err) {
         console.warn("カード取引カテゴリ判定失敗:", err.message);
         unique.forEach((t) => { t.categoryAuto = "その他"; });
@@ -201,11 +204,12 @@ async function appendCardTransactionsToSheet(spreadsheetId, cardName, transactio
     t.paymentMonth,
     cardName,
     t.categoryAuto ?? "",
+    t.excludeAuto ?? "",
   ]);
 
   await sheets.spreadsheets.values.append({
     spreadsheetId,
-    range: `${sheetName}!A:J`,
+    range: `${sheetName}!A:K`,
     valueInputOption: "USER_ENTERED",
     insertDataOption: "INSERT_ROWS",
     requestBody: { values },


### PR DESCRIPTION
## Summary

`category rules` シートにカテゴリ「除外」のルールを追加するだけで、インポート時に該当トランザクションの除外列が自動で埋まるようになります。

**設定例（category rules シートに追加）:**

| キーワード | カテゴリ | 登録日時 | ソース |
|-----------|---------|---------|-------|
| 楽天カード | 除外 | 2026/05/03 | 手動 |

**動作:**
- bank/card インポート時、カテゴリ判定で「除外」にマッチした行は除外列に「自動除外」を書き込む
- Gemini のカテゴリ候補には「除外」を含めないため、**ルール照合でのみ発動**（意図しない自動除外を防止）
- bank trans: I列、card trans: K列 にそれぞれ書き込む

## Changes

- `bankTransactionImporter.js`: `categoryAuto === "除外"` → `excludeAuto = "自動除外"`、range `A:H` → `A:I`
- `cardTransactionImporter.js`: `categoryAuto === "除外"` → `excludeAuto = "自動除外"`、range `A:J` → `A:K`

## Test plan

- [x] category rules に `楽天カード | 除外` を追加
- [x] `/bank/import` 実行後、楽天カード引き落とし行の I列に「自動除外」が記録されること
- [x] 集計（`/summary`）でその行が支出に含まれないこと
- [x] 「除外」ルールのない行は通常通りカテゴリが付与されること

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)