### PR TITLE
feat: LIFF ID トークンで /summary を認証

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,6 @@ CATEGORY_RULES_SHEET_NAME=category rules
 # LIFF アプリの URL（LINE Developers で登録後に設定）
 # 未設定の場合は LINE Bot のテキスト集計のみ返信（ボタンなし）
 LIFF_URL=https://liff.line.me/YOUR_LIFF_ID
+# LINE Login チャンネルの Channel ID（LIFF トークン検証に使用）
+# 未設定の場合は本番環境でも認証をスキップ（非推奨）
+LIFF_CHANNEL_ID=YOUR_LINE_LOGIN_CHANNEL_ID

--- a/public/summary.html
+++ b/public/summary.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
   <title>月別集計</title>
+  <script src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -332,6 +333,7 @@ const BADGE_CLASSES = { receipt: "badge-receipt", bank: "badge-bank", card: "bad
 let currentMonth = getMonthFromUrl();
 let chartInstance = null;
 let currentData = null;
+let idToken = null; // LIFF ID トークン（本番環境のみ）
 
 function getMonthFromUrl() {
   const p = new URLSearchParams(location.search);
@@ -365,6 +367,10 @@ function fmt(n) {
   return "¥" + Math.round(n).toLocaleString();
 }
 
+function authHeaders() {
+  return idToken ? { "Authorization": `Bearer ${idToken}` } : {};
+}
+
 async function loadData(month) {
   setMonthInUrl(month);
   document.getElementById("month-title").textContent = formatMonth(month);
@@ -375,7 +381,12 @@ async function loadData(month) {
 
   let data;
   try {
-    const res = await fetch(`/summary?month=${month}`);
+    const res = await fetch(`/summary?month=${month}`, { headers: authHeaders() });
+    if (res.status === 401) {
+      document.getElementById("main").innerHTML =
+        '<div class="state-msg">このページは LINE アプリから開いてください。</div>';
+      return;
+    }
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     data = await res.json();
   } catch (e) {
@@ -595,8 +606,35 @@ document.getElementById("sheet").addEventListener("touchend", e => {
   if (e.changedTouches[0].clientY - touchStartY > 60) closeSheet();
 }, { passive: true });
 
-// 初回ロード
-loadData(currentMonth);
+// ── 初期化（LIFF 認証 → データロード）──
+async function init() {
+  let config = { liffId: null };
+  try {
+    const res = await fetch("/config");
+    config = await res.json();
+  } catch (_) {}
+
+  if (config.liffId) {
+    // 本番: LIFF 初期化してトークン取得
+    try {
+      await liff.init({ liffId: config.liffId });
+      if (!liff.isInClient()) {
+        document.getElementById("main").innerHTML =
+          '<div class="state-msg">このページは LINE アプリから開いてください。</div>';
+        return;
+      }
+      idToken = liff.getIDToken();
+    } catch (err) {
+      document.getElementById("main").innerHTML =
+        `<div class="state-msg">LIFF の初期化に失敗しました。<br><small>${err.message}</small></div>`;
+      return;
+    }
+  }
+  // 開発環境（liffId なし）はそのままロード
+  loadData(currentMonth);
+}
+
+init();
 </script>
 </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const { handleEvent } = require("./lineHandler");
 const { importBankTransactions } = require("./bankTransactionImporter");
 const { importCardTransactions } = require("./cardTransactionImporter");
 const { aggregateByMonth } = require("./aggregationService");
+const { verifyLiffToken } = require("./liffAuth");
 
 const config = {
   channelSecret: process.env.LINE_CHANNEL_SECRET,
@@ -31,10 +32,20 @@ app.post("/webhook", middleware(config), (req, res) => {
 });
 
 /**
+ * SPA に LIFF ID を渡すための公開設定エンドポイント
+ * GET /config
+ */
+app.get("/config", (req, res) => {
+  const liffUrl = process.env.LIFF_URL || "";
+  const liffId = liffUrl.replace("https://liff.line.me/", "") || null;
+  res.json({ liffId });
+});
+
+/**
  * 月別集計 API
  * GET /summary?month=YYYY-MM
  */
-app.get("/summary", async (req, res) => {
+app.get("/summary", verifyLiffToken, async (req, res) => {
   const { month } = req.query;
   if (!month || !/^\d{4}-\d{2}$/.test(month)) {
     return res.status(400).json({ error: "month パラメータが必要です（例: 2026-04）" });

--- a/src/liffAuth.js
+++ b/src/liffAuth.js
@@ -1,0 +1,44 @@
+/**
+ * LIFF ID トークン検証ミドルウェア
+ *
+ * 本番環境（NODE_ENV=production）では LINE API でトークンを検証する。
+ * 開発環境では検証をスキップし、直接アクセスを許可する。
+ */
+async function verifyLiffToken(req, res, next) {
+  // 開発環境はスキップ
+  if (process.env.NODE_ENV !== "production") return next();
+
+  const channelId = process.env.LIFF_CHANNEL_ID;
+  if (!channelId) {
+    console.warn("LIFF_CHANNEL_ID が未設定のため認証をスキップします");
+    return next();
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "認証が必要です" });
+  }
+
+  const idToken = authHeader.slice(7);
+
+  try {
+    const resp = await fetch("https://api.line.me/oauth2/v2.1/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ id_token: idToken, client_id: channelId }),
+    });
+
+    if (!resp.ok) {
+      const body = await resp.json().catch(() => ({}));
+      console.warn("LIFF トークン検証失敗:", body);
+      return res.status(401).json({ error: "トークンが無効です" });
+    }
+
+    next();
+  } catch (err) {
+    console.error("LIFF トークン検証エラー:", err);
+    res.status(500).json({ error: "認証エラーが発生しました" });
+  }
+}
+
+module.exports = { verifyLiffToken };


### PR DESCRIPTION
## Summary

LIFF（LINE アプリ内ブラウザ）経由でのみ `/summary` にアクセスできるよう、LIFF ID トークン検証を追加します。

## 認証フロー

```
LINE アプリ → LIFF URL を開く
  → liff.init() で SDK 初期化
  → liff.getIDToken() で ID トークン取得
  → /summary リクエストに Authorization: Bearer <token>
  → サーバーが LINE API（/oauth2/v2.1/verify）で検証
  → 検証成功 → データ返却
```

## 動作条件

| 環境 | LIFF_CHANNEL_ID | 動作 |
|------|----------------|------|
| `NODE_ENV=production` | 設定済み | トークン検証あり |
| `NODE_ENV=production` | 未設定 | 警告ログのみ、検証スキップ |
| `NODE_ENV=development` | 任意 | 検証スキップ（直接アクセス可） |

## 追加した環境変数

`LIFF_CHANNEL_ID` — LINE Login チャンネルの Channel ID

## Test plan

- [x] ローカル（`NODE_ENV` 未設定）: `http://localhost:8080/summary.html` に直接アクセスできること
- [x] LINE アプリ内から LIFF URL を開くと正常に表示されること
- [x] 本番環境（`NODE_ENV=production`, `LIFF_CHANNEL_ID` 設定）でブラウザから直接 `/summary` にアクセスすると 401 が返ること
- [x] `LIFF_CHANNEL_ID` を `.env.local` に追加して ngrok 経由で LINE アプリからアクセスできること

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)