### PR TITLE
feat: 月別集計にメンバー別支払い集計を追加

### DIFF
--- a/public/summary.html
+++ b/public/summary.html
@@ -288,6 +288,20 @@
     }
     @keyframes spin { to { transform: rotate(360deg); } }
 
+    /* ── メンバーアバター ── */
+    .member-avatar {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      color: #fff;
+      font-size: 14px;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
     /* ── 空状態 ── */
     .empty { text-align: center; padding: 32px 16px; color: var(--text-muted); }
   </style>
@@ -489,6 +503,30 @@ function render(data) {
       </div>`;
   }
 
+  // ── メンバー別 ──
+  const sortedMembers = Object.entries(data.members || {})
+    .sort(([, a], [, b]) => b.total - a.total);
+  if (sortedMembers.length > 0) {
+    html += `<div class="list-section"><div class="list-section-title">メンバー別（レシート）</div>`;
+    sortedMembers.forEach(([name, m], i) => {
+      const color = PALETTE[(i + 3) % PALETTE.length];
+      const initial = escHtml([...name][0] || "?");
+      html += `
+        <div class="category-row" data-member="${escHtml(name)}">
+          <span class="member-avatar" style="background:${color}">${initial}</span>
+          <div class="cat-info">
+            <div class="cat-name">${escHtml(name)}</div>
+            <div class="cat-count">${m.transactions.length}件</div>
+          </div>
+          <div class="cat-right">
+            <span class="cat-amount">${fmt(m.total)}</span>
+            <span class="chevron">›</span>
+          </div>
+        </div>`;
+    });
+    html += `</div>`;
+  }
+
   main.innerHTML = html;
 
   // グラフ描画
@@ -526,8 +564,8 @@ function render(data) {
     });
   }
 
-  // カテゴリ行クリック
-  main.querySelectorAll(".category-row").forEach(row => {
+  // カテゴリ・入金行クリック
+  main.querySelectorAll(".category-row[data-cat]").forEach(row => {
     row.addEventListener("click", () => {
       const cat = row.dataset.cat;
       const color = cat === "__income__"
@@ -536,17 +574,35 @@ function render(data) {
       openSheet(cat, color, currentData);
     });
   });
+
+  // メンバー行クリック
+  main.querySelectorAll(".category-row[data-member]").forEach((row, i) => {
+    const color = PALETTE[(i + 3) % PALETTE.length];
+    row.addEventListener("click", () => {
+      openSheet("__member__" + row.dataset.member, color, currentData);
+    });
+  });
 }
 
 function openSheet(catKey, color, data) {
   const isIncome = catKey === "__income__";
+  const isMember = catKey.startsWith("__member__");
+  const memberName = isMember ? catKey.slice(10) : null;
+
   const transactions = isIncome
     ? data.income.transactions
-    : (data.categories[catKey]?.transactions || []);
-  const total = isIncome ? data.incomeTotal : (data.categories[catKey]?.total || 0);
+    : isMember
+      ? (data.members?.[memberName]?.transactions || [])
+      : (data.categories[catKey]?.transactions || []);
+  const total = isIncome
+    ? data.incomeTotal
+    : isMember
+      ? (data.members?.[memberName]?.total || 0)
+      : (data.categories[catKey]?.total || 0);
 
   document.getElementById("sheet-dot").style.background = color;
-  document.getElementById("sheet-title").textContent = isIncome ? "入金" : catKey;
+  document.getElementById("sheet-title").textContent =
+    isIncome ? "入金" : isMember ? memberName : catKey;
   document.getElementById("sheet-total").textContent = fmt(total);
 
   const body = document.getElementById("sheet-body");

--- a/src/aggregationService.js
+++ b/src/aggregationService.js
@@ -96,15 +96,37 @@ async function aggregateByMonth(spreadsheetId, month) {
     });
   }
 
-  // カテゴリ内をそれぞれ日付昇順でソート
+  // メンバー別集計（receipts のみ）
+  const members = {};
+  for (const row of receiptsRows) {
+    if (extractYearMonth(row[1]) !== month) continue;
+    if (row[11]) continue; // L列: 除外
+    const amount = parseFloat(row[6]) || 0;
+    if (!amount) continue;
+    const name = row[3] || "不明"; // D列: 表示名
+    if (!members[name]) members[name] = { total: 0, transactions: [] };
+    members[name].total += amount;
+    members[name].transactions.push({
+      date: String(row[1] || "").split(" ")[0],
+      label: row[5] || "",          // F列: 店名
+      amount,
+      source: "receipt",
+      detail: [row[10], row[7]].filter(Boolean).join("・"), // カテゴリ・支払方法
+    });
+  }
+
+  // カテゴリ・メンバーをそれぞれ日付昇順でソート
   for (const cat of Object.values(categories)) {
     cat.transactions.sort((a, b) => (a.date > b.date ? 1 : -1));
+  }
+  for (const m of Object.values(members)) {
+    m.transactions.sort((a, b) => (a.date > b.date ? 1 : -1));
   }
   income.transactions.sort((a, b) => (a.date > b.date ? 1 : -1));
 
   const expenseTotal = Object.values(categories).reduce((s, c) => s + c.total, 0);
 
-  return { month, expenseTotal, incomeTotal: income.total, categories, income };
+  return { month, expenseTotal, incomeTotal: income.total, categories, income, members };
 }
 
 function addTransaction(categories, category, tx) {

--- a/src/lineHandler.js
+++ b/src/lineHandler.js
@@ -55,12 +55,22 @@ async function handleTextMessage(event, client) {
 
   if (!categoryLines) categoryLines = "（データなし）";
 
+  // メンバー別レシート合計
+  const sortedMembers = Object.entries(data.members || {}).sort(
+    ([, a], [, b]) => b.total - a.total
+  );
+  const memberSection = sortedMembers.length > 0
+    ? `\n\n【レシート】\n` +
+      sortedMembers.map(([name, m]) => `${name}　¥${m.total.toLocaleString()}`).join("\n")
+    : "";
+
   const summaryText =
     `${title}\n\n` +
     `【支出カテゴリ別】\n${categoryLines}\n` +
     `──────────────\n` +
     `支出合計　¥${data.expenseTotal.toLocaleString()}\n\n` +
-    `【入金】\n入金合計　¥${data.incomeTotal.toLocaleString()}`;
+    `【入金】\n入金合計　¥${data.incomeTotal.toLocaleString()}` +
+    memberSection;
 
   const messages = [{ type: "text", text: summaryText }];
 


### PR DESCRIPTION
## Summary

月別集計 SPA の最下部に「メンバー別（レシート）」セクションを追加。  
グループメンバーがその月に自分がいくら払ったかを確認できます。

- 名前の頭文字アバター（カラー付き）+ 合計金額 + 件数
- タップでボトムシートドリルダウン（店名・金額・カテゴリ・支払方法）
- receipts シートの表示名（D列）でグループ化、除外行はスキップ
- 合計金額降順でソート

## Test plan

- [x] SPA の最下部にメンバー別セクションが表示されること
- [x] メンバー行をタップすると明細ドリルダウンが開くこと
- [x] 明細に カテゴリ・支払方法 が表示されること
- [x] 除外列（L列）にテキストがある行が含まれないこと

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)